### PR TITLE
Implement PrimaryKey for all &T where T implements PrimaryKey.

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -214,7 +214,7 @@ where
     T: Prefixer<'a>,
 {
     fn prefix(&self) -> Vec<Key> {
-        <T as Prefixer<'a>>::prefix(&self)
+        <T as Prefixer<'a>>::prefix(self)
     }
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -134,6 +134,21 @@ impl<'a, T: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize, U: PrimaryKey<'a> + 
     }
 }
 
+// implements PrimaryKey for all &T where T implements PrimaryKey.
+impl<'a, T> PrimaryKey<'a> for &'a T
+where
+    T: PrimaryKey<'a>,
+{
+    type Prefix = <T as PrimaryKey<'a>>::Prefix;
+    type SubPrefix = <T as PrimaryKey<'a>>::SubPrefix;
+    type Suffix = <T as PrimaryKey<'a>>::Suffix;
+    type SuperSuffix = <T as PrimaryKey<'a>>::SuperSuffix;
+
+    fn key(&self) -> Vec<Key> {
+        <T as PrimaryKey<'a>>::key(&self)
+    }
+}
+
 // use generics for combining there - so we can use &[u8], Vec<u8>, or IntKey
 impl<
         'a,
@@ -232,19 +247,6 @@ impl<'a> PrimaryKey<'a> for String {
 impl<'a> Prefixer<'a> for String {
     fn prefix(&self) -> Vec<Key> {
         vec![Key::Ref(self.as_bytes())]
-    }
-}
-
-/// type safe version to ensure address was validated before use.
-impl<'a> PrimaryKey<'a> for &'a Addr {
-    type Prefix = ();
-    type SubPrefix = ();
-    type Suffix = Self;
-    type SuperSuffix = Self;
-
-    fn key(&self) -> Vec<Key> {
-        // this is simple, we don't add more prefixes
-        vec![Key::Ref(self.as_ref().as_bytes())]
     }
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -141,11 +141,11 @@ where
 {
     type Prefix = <T as PrimaryKey<'a>>::Prefix;
     type SubPrefix = <T as PrimaryKey<'a>>::SubPrefix;
-    type Suffix = <T as PrimaryKey<'a>>::Suffix;
-    type SuperSuffix = <T as PrimaryKey<'a>>::SuperSuffix;
+    type Suffix = T::Suffix;
+    type SuperSuffix = T::SuperSuffix;
 
     fn key(&self) -> Vec<Key> {
-        <T as PrimaryKey<'a>>::key(&self)
+        <T as PrimaryKey<'a>>::key(self)
     }
 }
 
@@ -209,6 +209,15 @@ impl<'a, T: Prefixer<'a>, U: Prefixer<'a>, V: Prefixer<'a>> Prefixer<'a> for (T,
     }
 }
 
+impl<'a, T> Prefixer<'a> for &'a T
+where
+    T: Prefixer<'a>,
+{
+    fn prefix(&self) -> Vec<Key> {
+        <T as Prefixer<'a>>::prefix(&self)
+    }
+}
+
 // Provide a string version of this to raw encode strings
 impl<'a> Prefixer<'a> for &'a str {
     fn prefix(&self) -> Vec<Key> {
@@ -245,12 +254,6 @@ impl<'a> PrimaryKey<'a> for String {
 }
 
 impl<'a> Prefixer<'a> for String {
-    fn prefix(&self) -> Vec<Key> {
-        vec![Key::Ref(self.as_bytes())]
-    }
-}
-
-impl<'a> Prefixer<'a> for &'a Addr {
     fn prefix(&self) -> Vec<Key> {
         vec![Key::Ref(self.as_bytes())]
     }


### PR DESCRIPTION
```rust
    for<'a> &'a (K, u64): PrimaryKey<'a>,
```

This allows having type constraints like this for types that wrap storage-plus. In english: for all lifetimes `'a` `&'a (K, u64)` is a valid key. I need this generic in order to implement [`cw-future-map`](https://gist.github.com/0xekez/15fab6436ed593cbd59f0bdf7ecf1f61).