### PR TITLE
feat: add save and load raw

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1610,7 +1610,7 @@ mod test {
 
         TEST_MAP.save_raw(&mut store, "key1", &data).unwrap();
         assert!(!TEST_MAP.is_empty(&store));
-        let saved = TEST_MAP.load_raw(&mut store, "key1").unwrap();
+        let saved = TEST_MAP.load_raw(&store, "key1").unwrap();
         assert_eq!(data, saved);
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -1597,5 +1597,17 @@ mod test {
         assert_eq!(None, john.may_load(&store).unwrap());
         john.save_raw(&mut store, &to_vec(&data).unwrap()).unwrap();
         assert_eq!(to_vec(&data).unwrap(), john.load_raw(&store).unwrap());
+
+        const TEST_MAP: Map<&str, Vec<u8>> = Map::new("test_map");
+        assert!(TEST_MAP.is_empty(&store));
+        let data:Vec<u8> = vec![40,55,60];
+
+        TEST_MAP.save_raw(&mut store, "key1", &data).unwrap();
+        assert!(!TEST_MAP.is_empty(&store));
+        let saved= TEST_MAP.load_raw(&mut store, "key1").unwrap();
+        assert_eq!(data,saved);
+
+
+
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -60,6 +60,10 @@ where
         self.key(k).save(store, data)
     }
 
+    pub fn save_raw(&self, store: &mut dyn Storage, k: K, data: &[u8]) -> StdResult<()> {
+        self.key(k).save_raw(store, data)
+    }
+
     pub fn remove(&self, store: &mut dyn Storage, k: K) {
         self.key(k).remove(store)
     }
@@ -67,6 +71,10 @@ where
     /// load will return an error if no data is set at the given key, or on parse error
     pub fn load(&self, store: &dyn Storage, k: K) -> StdResult<T> {
         self.key(k).load(store)
+    }
+
+    pub fn load_raw(&self, store: &dyn Storage, k: K) -> Option<Vec<u8>>{
+        self.key(k).load_raw(store)
     }
 
     /// may_load will parse the data stored at the key if present, returns Ok(None) if no data there.

--- a/src/map.rs
+++ b/src/map.rs
@@ -73,7 +73,7 @@ where
         self.key(k).load(store)
     }
 
-    pub fn load_raw(&self, store: &dyn Storage, k: K) -> Option<Vec<u8>>{
+    pub fn load_raw(&self, store: &dyn Storage, k: K) -> Option<Vec<u8>> {
         self.key(k).load_raw(store)
     }
 
@@ -304,9 +304,9 @@ mod test {
     use serde::{Deserialize, Serialize};
     use std::ops::Deref;
 
-    use cosmwasm_std::testing::MockStorage;
     use cosmwasm_std::to_binary;
     use cosmwasm_std::StdError::InvalidUtf8;
+    use cosmwasm_std::{testing::MockStorage, to_vec};
     #[cfg(feature = "iterator")]
     use cosmwasm_std::{Order, StdResult};
 
@@ -1584,5 +1584,18 @@ mod test {
         TEST_MAP.save(&mut storage, "key2", &2u32).unwrap();
 
         assert!(!TEST_MAP.is_empty(&storage));
+    }
+
+    #[test]
+    fn save_and_load_raw() {
+        let mut store = MockStorage::new();
+        let john = PEOPLE.key(b"john");
+        let data = Data {
+            name: "John".to_string(),
+            age: 32,
+        };
+        assert_eq!(None, john.may_load(&store).unwrap());
+        john.save_raw(&mut store, &to_vec(&data).unwrap()).unwrap();
+        assert_eq!(to_vec(&data).unwrap(), john.load_raw(&store).unwrap());
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -1587,7 +1587,7 @@ mod test {
     }
 
     #[test]
-    fn save_and_load_raw() {
+    fn save_and_load_raw_item() {
         let mut store = MockStorage::new();
         let john = PEOPLE.key(b"john");
         let data = Data {
@@ -1597,17 +1597,20 @@ mod test {
         assert_eq!(None, john.may_load(&store).unwrap());
         john.save_raw(&mut store, &to_vec(&data).unwrap()).unwrap();
         assert_eq!(to_vec(&data).unwrap(), john.load_raw(&store).unwrap());
+    }
+
+    #[test]
+    #[cfg(feature = "iterator")]
+    fn save_and_load_raw_map() {
+        let mut store = MockStorage::new();
 
         const TEST_MAP: Map<&str, Vec<u8>> = Map::new("test_map");
         assert!(TEST_MAP.is_empty(&store));
-        let data:Vec<u8> = vec![40,55,60];
+        let data: Vec<u8> = vec![40, 55, 60];
 
         TEST_MAP.save_raw(&mut store, "key1", &data).unwrap();
         assert!(!TEST_MAP.is_empty(&store));
-        let saved= TEST_MAP.load_raw(&mut store, "key1").unwrap();
-        assert_eq!(data,saved);
-
-
-
+        let saved = TEST_MAP.load_raw(&mut store, "key1").unwrap();
+        assert_eq!(data, saved);
     }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -72,8 +72,7 @@ where
     }
 
     pub fn load_raw(&self, store: &dyn Storage) -> Option<Vec<u8>> {
-        let value = store.get(&self.storage_key);
-        value
+        store.get(&self.storage_key)
     }
 
     /// may_load will parse the data stored at the key if present, returns Ok(None) if no data there.

--- a/src/path.rs
+++ b/src/path.rs
@@ -52,7 +52,12 @@ where
 
     /// save will serialize the model and store, returns an error on serialization issues
     pub fn save(&self, store: &mut dyn Storage, data: &T) -> StdResult<()> {
-        store.set(&self.storage_key, &to_vec(data)?);
+        self.save_raw(store, &to_vec(data)?)?;
+        Ok(())
+    }
+
+    pub fn save_raw(&self, store: &mut dyn Storage, data: &[u8]) -> StdResult<()> {
+        store.set(&self.storage_key, data);
         Ok(())
     }
 
@@ -62,14 +67,19 @@ where
 
     /// load will return an error if no data is set at the given key, or on parse error
     pub fn load(&self, store: &dyn Storage) -> StdResult<T> {
-        let value = store.get(&self.storage_key);
+        let value = self.load_raw(store);
         must_deserialize(&value)
+    }
+
+    pub fn load_raw(&self, store: &dyn Storage) -> Option<Vec<u8>> {
+        let value = store.get(&self.storage_key);
+        value
     }
 
     /// may_load will parse the data stored at the key if present, returns Ok(None) if no data there.
     /// returns an error on issues parsing
     pub fn may_load(&self, store: &dyn Storage) -> StdResult<Option<T>> {
-        let value = store.get(&self.storage_key);
+        let value = self.load_raw(store);
         may_deserialize(&value)
     }
 


### PR DESCRIPTION
When saving raw bytes the storage seems to json serialize the bytes and save bytes of its serialized string which creates problem when we do abci query for storage proof since it is now providing proof for the serialized string bytes rather than the original bytes. 

Plus it has unnecessary performance panalties when we want to just save and load raw bytes. I have tried to fix by adding public method to save and load raw bytes but not sure if it will have any negative impact on overall api design. 