### PR TITLE
DO NOT MERGE: Add prost support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ workflows:
 jobs:
   build_and_test:
     docker:
-      - image: rust:1.64.0
+      - image: rust:1.70.0
     working_directory: ~/project/
     steps:
       - checkout
@@ -51,7 +51,7 @@ jobs:
           command: rustup target add wasm32-unknown-unknown && rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-storage-plus:1.64.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-storage-plus:1.70.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Build library for native target (no iterator)
           command: cargo build --locked --no-default-features
@@ -74,7 +74,7 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-storage-plus:1.64.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-storage-plus:1.70.0-{{ checksum "Cargo.lock" }}
 
   build_minimal:
     docker:
@@ -90,7 +90,7 @@ jobs:
           command: rm Cargo.lock
       - restore_cache:
           keys:
-            - cargocache-v2-storage-plus:1.64.0-minimal-{{ checksum "~/project/Cargo.toml" }}
+            - cargocache-v2-storage-plus:1.70.0-minimal-{{ checksum "~/project/Cargo.toml" }}
       - run:
           name: Build library for native target (with iterator and macro)
           command: cargo build -Zminimal-versions --all-features
@@ -101,11 +101,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-storage-plus:1.64.0-minimal-{{ checksum "~/project/Cargo.toml" }}
+          key: cargocache-v2-storage-plus:1.70.0-minimal-{{ checksum "~/project/Cargo.toml" }}
 
   build_maximal:
     docker:
-      - image: rust:1.64.0
+      - image: rust:1.70.0
     working_directory: ~/project/
     steps:
       - checkout
@@ -117,7 +117,7 @@ jobs:
           command: cargo update
       - restore_cache:
           keys:
-            - cargocache-v2-storage-plus:1.64.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-storage-plus:1.70.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Build library for native target (with iterator and macro)
           command: cargo build --locked --all-features
@@ -128,11 +128,11 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-storage-plus:1.64.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-storage-plus:1.70.0-{{ checksum "Cargo.lock" }}
 
   lint:
     docker:
-      - image: rust:1.64.0
+      - image: rust:1.70.0
     steps:
       - checkout
       - run:
@@ -140,7 +140,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - restore_cache:
           keys:
-            - cargocache-v2-lint-rust:1.64.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-lint-rust:1.70.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Add rustfmt component
           command: rustup component add rustfmt
@@ -159,11 +159,11 @@ jobs:
             - target/debug/.fingerprint
             - target/debug/build
             - target/debug/deps
-          key: cargocache-v2-lint-rust:1.64.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-lint-rust:1.70.0-{{ checksum "Cargo.lock" }}
 
   benchmarking:
     docker:
-      - image: rust:1.64.0
+      - image: rust:1.70.0
     environment:
       RUST_BACKTRACE: 1
     steps:
@@ -173,7 +173,7 @@ jobs:
           command: rustc --version && cargo --version
       - restore_cache:
           keys:
-            - cargocache-v2-benchmarking-rust:1.64.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-benchmarking-rust:1.70.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Run storage-plus benchmarks
           working_directory: ~/project
@@ -182,7 +182,7 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-benchmarking-rust:1.64.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-benchmarking-rust:1.70.0-{{ checksum "Cargo.lock" }}
 
   coverage:
     # https://circleci.com/developer/images?imageType=machine

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,38 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -27,15 +53,15 @@ checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64ct"
-version = "1.5.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bitflags"
@@ -54,36 +80,36 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
-name = "bstr"
-version = "0.2.17"
+name = "bnum"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
- "serde",
-]
+checksum = "845141a4fade3f790628b7daaaa298a25b204fb28907eb54febe5142db6ce653"
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cast"
@@ -110,17 +136,16 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
+checksum = "6340df57935414636969091153f35f68d9f00bbc8fb4a9c6054706c213e6c6bc"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532d2ba11b7157e3b67114389925568af29ce3e452b582d6bdfe751cb2dadfb1"
+version = "1.3.0-rc.0"
+source = "git+https://github.com/CosmWasm/cosmwasm.git?branch=add-prost-support#17f612230fcf319fd41ec13efc8d4b28abb67b29"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.7",
  "ed25519-zebra",
  "k256",
  "rand_core 0.6.4",
@@ -129,37 +154,60 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8568b289cc366981319ab39edd85d666456456f7c126433ef065ebe5257f27b2"
+version = "1.3.0-rc.0"
+source = "git+https://github.com/CosmWasm/cosmwasm.git?branch=add-prost-support#17f612230fcf319fd41ec13efc8d4b28abb67b29"
 dependencies = [
- "syn",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "cosmwasm-schema"
+version = "1.3.0-rc.0"
+source = "git+https://github.com/CosmWasm/cosmwasm.git?branch=add-prost-support#17f612230fcf319fd41ec13efc8d4b28abb67b29"
+dependencies = [
+ "cosmwasm-schema-derive",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "cosmwasm-schema-derive"
+version = "1.3.0-rc.0"
+source = "git+https://github.com/CosmWasm/cosmwasm.git?branch=add-prost-support#17f612230fcf319fd41ec13efc8d4b28abb67b29"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1ceebd520a10167e35080e4f55f6b0284bb8ea364dec0f22197da96acd9e64"
+version = "1.3.0-rc.0"
+source = "git+https://github.com/CosmWasm/cosmwasm.git?branch=add-prost-support#17f612230fcf319fd41ec13efc8d4b28abb67b29"
 dependencies = [
  "base64",
+ "bnum",
  "cosmwasm-crypto",
  "cosmwasm-derive",
+ "cosmwasm-schema",
  "derivative",
  "forward_ref",
  "hex",
+ "prost",
  "schemars",
  "serde",
  "serde-json-wasm",
+ "sha2 0.10.7",
  "thiserror",
- "uint",
 ]
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -202,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -212,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -223,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.11"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -236,18 +284,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.12"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
@@ -273,13 +315,12 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.6"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+checksum = "626ae34994d3d8d668f4269922248239db4ae42d538b14c398b74a52208e8086"
 dependencies = [
- "bstr",
  "csv-core",
- "itoa 0.4.8",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -310,16 +351,18 @@ dependencies = [
 name = "cw-storage-macro"
 version = "1.1.0"
 dependencies = [
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "cw-storage-plus"
 version = "1.1.0"
 dependencies = [
+ "cosmwasm-schema",
  "cosmwasm-std",
  "criterion",
  "cw-storage-macro",
+ "prost",
  "rand",
  "rand_xoshiro",
  "schemars",
@@ -329,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -345,7 +388,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -359,20 +402,20 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.5"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.3",
+ "block-buffer 0.10.4",
  "crypto-common",
  "subtle",
 ]
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
+checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
 name = "ecdsa"
@@ -388,24 +431,24 @@ dependencies = [
 
 [[package]]
 name = "ed25519-zebra"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403ef3e961ab98f0ba902771d29f842058578bb1ce7e3c59dad5a6a93e784c69"
+checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
 dependencies = [
  "curve25519-dalek",
+ "hashbrown",
  "hex",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.9.9",
- "thiserror",
  "zeroize",
 ]
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
@@ -416,7 +459,7 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
- "digest 0.10.5",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -429,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -445,9 +488,9 @@ checksum = "c8cbd1169bd7b4a0a20d92b9af7a7e0422888bd38a6f5ec29c1fd8c1558a272e"
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -455,24 +498,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -493,6 +525,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +541,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hex"
@@ -513,7 +560,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -527,21 +574,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -555,7 +596,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.6",
+ "sha2 0.10.7",
 ]
 
 [[package]]
@@ -566,18 +607,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.135"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "memchr"
@@ -587,9 +625,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
@@ -605,19 +643,19 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.2",
  "libc",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "oorandom"
@@ -643,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "plotters"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -656,33 +694,56 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
 dependencies = [
  "plotters-backend",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.21"
+name = "prost"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -701,9 +762,6 @@ name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
 
 [[package]]
 name = "rand_core"
@@ -711,7 +769,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom",
 ]
 
 [[package]]
@@ -725,21 +783,19 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -749,30 +805,38 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+checksum = "e9aaecc05d5c4b5f7da074b9a0d1a0867e71fd36e7fc0482d8bcfe8e8fc56290"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
 
 [[package]]
 name = "rfc6979"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c86280f057430a52f4861551b092a01b419b8eacefc7c995eacb9dc132fe32"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint",
  "hmac",
@@ -781,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
 
 [[package]]
 name = "same-file"
@@ -796,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a5fb6c61f29e723026dc8e923d94c694313212abbecbbe5f55a7748eec5b307"
+checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -808,14 +872,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f188d036977451159430f3b8dc82ec76364a42b7e289c2b18a9a18f4470058e9"
+checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -840,18 +904,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "7daf513456463b42aa1d94cff7e0c24d682b429f020b9afa4f5ba5c40a22b237"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479b4dbc401ca13ee8ce902851b834893251404c4f3c65370a49e047a6be09a5"
+checksum = "16a62a1fad1e1828b24acac8f2b468971dade7b8c3c2e672bcadefefb1f8c137"
 dependencies = [
  "serde",
 ]
@@ -868,13 +932,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "b69b106b68bc8054f0e974e70d19984040f8a5cf9215ca82626ea4853f82c4b9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -885,16 +949,16 @@ checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.86"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
+checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
 dependencies = [
- "itoa 1.0.4",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -914,13 +978,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.5",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -929,7 +993,7 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -944,22 +1008,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "1.0.102"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -977,22 +1046,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1007,27 +1076,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
-
-[[package]]
-name = "uint"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45526d29728d135c2900b0d30573fe3ee79fceb12ef534c7bb30e810a91b601"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
 name = "unicode-width"
@@ -1043,20 +1100,13 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -1066,9 +1116,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1076,24 +1126,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.23",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1101,28 +1151,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.23",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1161,6 +1211,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ checksum = "6340df57935414636969091153f35f68d9f00bbc8fb4a9c6054706c213e6c6bc"
 [[package]]
 name = "cosmwasm-crypto"
 version = "1.3.0-rc.0"
-source = "git+https://github.com/CosmWasm/cosmwasm.git?branch=add-prost-support#17f612230fcf319fd41ec13efc8d4b28abb67b29"
+source = "git+https://github.com/CosmWasm/cosmwasm.git?branch=add-prost-support#11461e4ee290f158ac570a3064e67b4e0f838fe5"
 dependencies = [
  "digest 0.10.7",
  "ed25519-zebra",
@@ -155,7 +155,7 @@ dependencies = [
 [[package]]
 name = "cosmwasm-derive"
 version = "1.3.0-rc.0"
-source = "git+https://github.com/CosmWasm/cosmwasm.git?branch=add-prost-support#17f612230fcf319fd41ec13efc8d4b28abb67b29"
+source = "git+https://github.com/CosmWasm/cosmwasm.git?branch=add-prost-support#11461e4ee290f158ac570a3064e67b4e0f838fe5"
 dependencies = [
  "syn 1.0.109",
 ]
@@ -163,7 +163,7 @@ dependencies = [
 [[package]]
 name = "cosmwasm-schema"
 version = "1.3.0-rc.0"
-source = "git+https://github.com/CosmWasm/cosmwasm.git?branch=add-prost-support#17f612230fcf319fd41ec13efc8d4b28abb67b29"
+source = "git+https://github.com/CosmWasm/cosmwasm.git?branch=add-prost-support#11461e4ee290f158ac570a3064e67b4e0f838fe5"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -175,7 +175,7 @@ dependencies = [
 [[package]]
 name = "cosmwasm-schema-derive"
 version = "1.3.0-rc.0"
-source = "git+https://github.com/CosmWasm/cosmwasm.git?branch=add-prost-support#17f612230fcf319fd41ec13efc8d4b28abb67b29"
+source = "git+https://github.com/CosmWasm/cosmwasm.git?branch=add-prost-support#11461e4ee290f158ac570a3064e67b4e0f838fe5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -185,7 +185,7 @@ dependencies = [
 [[package]]
 name = "cosmwasm-std"
 version = "1.3.0-rc.0"
-source = "git+https://github.com/CosmWasm/cosmwasm.git?branch=add-prost-support#17f612230fcf319fd41ec13efc8d4b28abb67b29"
+source = "git+https://github.com/CosmWasm/cosmwasm.git?branch=add-prost-support#11461e4ee290f158ac570a3064e67b4e0f838fe5"
 dependencies = [
  "base64",
  "bnum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,12 @@ macro = ["cw-storage-macro"]
 bench = false
 
 [dependencies]
-cosmwasm-std = { version = "1.1.6", default-features = false }
+cosmwasm-std = { git = "https://github.com/CosmWasm/cosmwasm.git", branch = "add-prost-support", default-features = false }
+cosmwasm-schema = { git = "https://github.com/CosmWasm/cosmwasm.git", branch = "add-prost-support", default-features = false }
 schemars = "0.8.3"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 cw-storage-macro = { version = "1.1.0", optional = true, path = "macros" }
+prost = "0.11"
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/src/deque.rs
+++ b/src/deque.rs
@@ -1,7 +1,6 @@
 use std::{any::type_name, convert::TryInto, marker::PhantomData};
 
-use cosmwasm_std::{to_vec, StdError, StdResult, Storage};
-use serde::{de::DeserializeOwned, Serialize};
+use cosmwasm_std::{prost::to_vec, StdError, StdResult, Storage};
 
 use crate::helpers::{may_deserialize, namespaces_with_key};
 
@@ -30,7 +29,7 @@ impl<'a, T> Deque<'a, T> {
     }
 }
 
-impl<'a, T: Serialize + DeserializeOwned> Deque<'a, T> {
+impl<'a, T: prost::Message + Default> Deque<'a, T> {
     /// Adds the given value to the end of the deque
     pub fn push_back(&self, storage: &mut dyn Storage, value: &T) -> StdResult<()> {
         // save value
@@ -196,7 +195,7 @@ fn calc_len(head: u32, tail: u32) -> u32 {
     tail.wrapping_sub(head)
 }
 
-impl<'a, T: Serialize + DeserializeOwned> Deque<'a, T> {
+impl<'a, T: prost::Message + Default> Deque<'a, T> {
     pub fn iter(&self, storage: &'a dyn Storage) -> StdResult<DequeIter<T>> {
         Ok(DequeIter {
             deque: self,
@@ -209,7 +208,7 @@ impl<'a, T: Serialize + DeserializeOwned> Deque<'a, T> {
 
 pub struct DequeIter<'a, T>
 where
-    T: Serialize + DeserializeOwned,
+    T: prost::Message + Default,
 {
     deque: &'a Deque<'a, T>,
     storage: &'a dyn Storage,
@@ -219,7 +218,7 @@ where
 
 impl<'a, T> Iterator for DequeIter<'a, T>
 where
-    T: Serialize + DeserializeOwned,
+    T: prost::Message + Default,
 {
     type Item = StdResult<T>;
 
@@ -260,7 +259,7 @@ where
 
 impl<'a, T> DoubleEndedIterator for DequeIter<'a, T>
 where
-    T: Serialize + DeserializeOwned,
+    T: prost::Message + Default,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.start == self.end {
@@ -292,9 +291,9 @@ where
 mod tests {
     use crate::deque::Deque;
 
+    use cosmwasm_schema::cw_prost;
     use cosmwasm_std::testing::MockStorage;
     use cosmwasm_std::{StdError, StdResult};
-    use serde::{Deserialize, Serialize};
 
     #[test]
     fn push_and_pop() {
@@ -496,9 +495,11 @@ mod tests {
         assert_eq!(deque.front(&store).unwrap(), Some(3));
     }
 
-    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    #[cw_prost]
     struct Data {
+        #[prost(string, tag = "1")]
         pub name: String,
+        #[prost(int32, tag = "2")]
         pub age: i32,
     }
 

--- a/src/indexed_map.rs
+++ b/src/indexed_map.rs
@@ -3,8 +3,6 @@
 
 use crate::PrefixBound;
 use cosmwasm_std::{StdError, StdResult, Storage};
-use serde::de::DeserializeOwned;
-use serde::Serialize;
 
 use crate::de::KeyDeserialize;
 use crate::indexes::Index;
@@ -22,7 +20,7 @@ pub trait IndexList<T> {
 pub struct IndexedMap<'a, K, T, I>
 where
     K: PrimaryKey<'a>,
-    T: Serialize + DeserializeOwned + Clone,
+    T: prost::Message + Clone + Default,
     I: IndexList<T>,
 {
     pk_namespace: &'a [u8],
@@ -35,7 +33,7 @@ where
 impl<'a, K, T, I> IndexedMap<'a, K, T, I>
 where
     K: PrimaryKey<'a>,
-    T: Serialize + DeserializeOwned + Clone,
+    T: prost::Message + Clone + Default,
     I: IndexList<T>,
 {
     pub const fn new(pk_namespace: &'a str, indexes: I) -> Self {
@@ -54,7 +52,7 @@ where
 impl<'a, K, T, I> IndexedMap<'a, K, T, I>
 where
     K: PrimaryKey<'a>,
-    T: Serialize + DeserializeOwned + Clone,
+    T: prost::Message + Clone + Default,
     I: IndexList<T>,
 {
     /// save will serialize the model and store, returns an error on serialization issues.
@@ -171,7 +169,7 @@ where
 impl<'a, K, T, I> IndexedMap<'a, K, T, I>
 where
     K: PrimaryKey<'a>,
-    T: Serialize + DeserializeOwned + Clone,
+    T: prost::Message + Clone + Default,
     I: IndexList<T>,
 {
     /// While `range_raw` over a `prefix` fixes the prefix to one element and iterates over the
@@ -199,7 +197,7 @@ where
 #[cfg(feature = "iterator")]
 impl<'a, K, T, I> IndexedMap<'a, K, T, I>
 where
-    T: Serialize + DeserializeOwned + Clone,
+    T: prost::Message + Clone + Default,
     K: PrimaryKey<'a>,
     I: IndexList<T>,
 {
@@ -215,7 +213,7 @@ where
 #[cfg(feature = "iterator")]
 impl<'a, K, T, I> IndexedMap<'a, K, T, I>
 where
-    T: Serialize + DeserializeOwned + Clone,
+    T: prost::Message + Clone + Default,
     K: PrimaryKey<'a> + KeyDeserialize,
     I: IndexList<T>,
 {
@@ -305,14 +303,17 @@ mod test {
 
     use crate::indexes::test::{index_string_tuple, index_tuple};
     use crate::{MultiIndex, UniqueIndex};
+    use cosmwasm_schema::cw_prost;
     use cosmwasm_std::testing::MockStorage;
     use cosmwasm_std::{MemoryStorage, Order};
-    use serde::{Deserialize, Serialize};
 
-    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    #[cw_prost]
     struct Data {
+        #[prost(string, tag = "1")]
         pub name: String,
+        #[prost(string, tag = "2")]
         pub last_name: String,
+        #[prost(uint32, tag = "3")]
         pub age: u32,
     }
 

--- a/src/indexed_snapshot.rs
+++ b/src/indexed_snapshot.rs
@@ -31,10 +31,13 @@ where
     ///
     /// ```rust
     /// use cw_storage_plus::{IndexedSnapshotMap, Strategy, UniqueIndex};
+    /// use cosmwasm_schema::cw_prost;
     ///
-    /// #[derive(PartialEq, Debug, Clone)]
+    /// #[cw_prost]
     /// struct Data {
+    ///     #[prost(string, tag = "1")]
     ///     pub name: String,
+    ///     #[prost(uint32, tag = "2")]
     ///     pub age: u32,
     /// }
     ///

--- a/src/indexes/mod.rs
+++ b/src/indexes/mod.rs
@@ -6,16 +6,13 @@ mod unique;
 pub use multi::MultiIndex;
 pub use unique::UniqueIndex;
 
-use serde::de::DeserializeOwned;
-use serde::Serialize;
-
 use cosmwasm_std::{StdResult, Storage};
 
 // Note: we cannot store traits with generic functions inside `Box<dyn Index>`,
 // so I pull S: Storage to a top-level
 pub trait Index<T>
 where
-    T: Serialize + DeserializeOwned + Clone,
+    T: prost::Message + Clone + Default,
 {
     fn save(&self, store: &mut dyn Storage, pk: &[u8], data: &T) -> StdResult<()>;
     fn remove(&self, store: &mut dyn Storage, pk: &[u8], old_data: &T) -> StdResult<()>;

--- a/src/indexes/unique.rs
+++ b/src/indexes/unique.rs
@@ -52,9 +52,13 @@ where
     ///
     /// ```rust
     /// use cw_storage_plus::UniqueIndex;
+    /// use cosmwasm_schema::cw_prost;
     ///
+    /// #[cw_prost]
     /// struct Data {
+    ///     #[prost(string, tag="1")]
     ///     pub name: String,
+    ///     #[prost(uint32, tag="2")]
     ///     pub age: u32,
     /// }
     ///

--- a/src/iter_helpers.rs
+++ b/src/iter_helpers.rs
@@ -1,21 +1,19 @@
 #![cfg(feature = "iterator")]
 
-use serde::de::DeserializeOwned;
-
 use cosmwasm_std::Record;
-use cosmwasm_std::{from_slice, StdResult};
+use cosmwasm_std::{prost::from_slice, StdResult};
 
 use crate::de::KeyDeserialize;
 use crate::helpers::encode_length;
 
 #[allow(dead_code)]
-pub(crate) fn deserialize_v<T: DeserializeOwned>(kv: Record) -> StdResult<Record<T>> {
+pub(crate) fn deserialize_v<T: prost::Message + Default>(kv: Record) -> StdResult<Record<T>> {
     let (k, v) = kv;
     let t = from_slice::<T>(&v)?;
     Ok((k, t))
 }
 
-pub(crate) fn deserialize_kv<K: KeyDeserialize, T: DeserializeOwned>(
+pub(crate) fn deserialize_kv<K: KeyDeserialize, T: prost::Message + Default>(
     kv: Record,
 ) -> StdResult<(K::Output, T)> {
     let (k, v) = kv;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ pub use snapshot::{SnapshotItem, SnapshotMap, Strategy};
 
 // cw_storage_macro reexports
 #[cfg(all(feature = "iterator", feature = "macro"))]
+#[allow(unused_imports)]
 #[macro_use]
 extern crate cw_storage_macro;
 #[cfg(all(feature = "iterator", feature = "macro"))]
@@ -76,7 +77,7 @@ extern crate cw_storage_macro;
 ///     id: u64,
 ///     #[prost(uint32, tag="2")]
 ///     id2: u32,
-///     #[prost(message, tag="3")]
+///     #[prost(message, required, tag="3")]
 ///     addr: Addr,
 /// }
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,12 +68,15 @@ extern crate cw_storage_macro;
 /// ```rust
 /// use cosmwasm_std::Addr;
 /// use cw_storage_plus::{MultiIndex, UniqueIndex, index_list};
-/// use serde::{Serialize, Deserialize};
+/// use cosmwasm_schema::cw_prost;
 ///
-/// #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+/// #[cw_prost]
 /// struct TestStruct {
+///     #[prost(uint64, tag="1")]
 ///     id: u64,
+///     #[prost(uint32, tag="2")]
 ///     id2: u32,
+///     #[prost(message, tag="3")]
 ///     addr: Addr,
 /// }
 ///

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,16 +1,14 @@
-use serde::de::DeserializeOwned;
-use serde::Serialize;
 use std::marker::PhantomData;
 
 use crate::helpers::{may_deserialize, must_deserialize, nested_namespaces_with_key};
 use crate::keys::Key;
-use cosmwasm_std::{to_vec, StdError, StdResult, Storage};
+use cosmwasm_std::{prost::to_vec, StdError, StdResult, Storage};
 use std::ops::Deref;
 
 #[derive(Debug, Clone)]
 pub struct Path<T>
 where
-    T: Serialize + DeserializeOwned,
+    T: prost::Message + Default,
 {
     /// all namespaces prefixes and concatenated with the key
     pub(crate) storage_key: Vec<u8>,
@@ -20,7 +18,7 @@ where
 
 impl<T> Deref for Path<T>
 where
-    T: Serialize + DeserializeOwned,
+    T: prost::Message + Default,
 {
     type Target = [u8];
 
@@ -31,7 +29,7 @@ where
 
 impl<T> Path<T>
 where
-    T: Serialize + DeserializeOwned,
+    T: prost::Message + Default,
 {
     pub fn new(namespace: &[u8], keys: &[&[u8]]) -> Self {
         let l = keys.len();

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -351,6 +351,7 @@ fn increment_last_byte(input: &[u8]) -> Vec<u8> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use cosmwasm_std::prost::to_vec;
     use cosmwasm_std::testing::MockStorage;
 
     #[test]
@@ -366,12 +367,12 @@ mod test {
         };
 
         // set some data, we care about "foo" prefix
-        store.set(b"foobar", b"1");
-        store.set(b"foora", b"2");
-        store.set(b"foozi", b"3");
+        store.set(b"foobar", &to_vec(&1u64).unwrap());
+        store.set(b"foora", &to_vec(&2u64).unwrap());
+        store.set(b"foozi", &to_vec(&3u64).unwrap());
         // these shouldn't match
-        store.set(b"foply", b"100");
-        store.set(b"font", b"200");
+        store.set(b"foply", &to_vec(&100u64).unwrap());
+        store.set(b"font", &to_vec(&200u64).unwrap());
 
         let expected = vec![
             (b"bar".to_vec(), 1u64),

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -1,7 +1,5 @@
 #![cfg(feature = "iterator")]
 use core::fmt;
-use serde::de::DeserializeOwned;
-use serde::Serialize;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
@@ -20,7 +18,7 @@ type DeserializeVFn<T> = fn(&dyn Storage, &[u8], Record) -> StdResult<Record<T>>
 type DeserializeKvFn<K, T> =
     fn(&dyn Storage, &[u8], Record) -> StdResult<(<K as KeyDeserialize>::Output, T)>;
 
-pub fn default_deserializer_v<T: DeserializeOwned>(
+pub fn default_deserializer_v<T: prost::Message + Default>(
     _: &dyn Storage,
     _: &[u8],
     raw: Record,
@@ -28,7 +26,7 @@ pub fn default_deserializer_v<T: DeserializeOwned>(
     deserialize_v(raw)
 }
 
-pub fn default_deserializer_kv<K: KeyDeserialize, T: DeserializeOwned>(
+pub fn default_deserializer_kv<K: KeyDeserialize, T: prost::Message + Default>(
     _: &dyn Storage,
     _: &[u8],
     raw: Record,
@@ -40,7 +38,7 @@ pub fn default_deserializer_kv<K: KeyDeserialize, T: DeserializeOwned>(
 pub struct Prefix<K, T, B = Vec<u8>>
 where
     K: KeyDeserialize,
-    T: Serialize + DeserializeOwned,
+    T: prost::Message + Default,
 {
     /// all namespaces prefixes and concatenated with the key
     storage_prefix: Vec<u8>,
@@ -54,7 +52,7 @@ where
 impl<K, T> Debug for Prefix<K, T>
 where
     K: KeyDeserialize,
-    T: Serialize + DeserializeOwned,
+    T: prost::Message + Default,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Prefix")
@@ -67,7 +65,7 @@ where
 impl<K, T> Deref for Prefix<K, T>
 where
     K: KeyDeserialize,
-    T: Serialize + DeserializeOwned,
+    T: prost::Message + Default,
 {
     type Target = [u8];
 
@@ -79,7 +77,7 @@ where
 impl<K, T, B> Prefix<K, T, B>
 where
     K: KeyDeserialize,
-    T: Serialize + DeserializeOwned,
+    T: prost::Message + Default,
 {
     pub fn new(top_name: &[u8], sub_names: &[Key]) -> Self {
         Prefix::with_deserialization_functions(
@@ -113,7 +111,7 @@ impl<'b, K, T, B> Prefix<K, T, B>
 where
     B: PrimaryKey<'b>,
     K: KeyDeserialize,
-    T: Serialize + DeserializeOwned,
+    T: prost::Message + Default,
 {
     pub fn range_raw<'a>(
         &self,

--- a/src/snapshot/item.rs
+++ b/src/snapshot/item.rs
@@ -1,6 +1,3 @@
-use serde::de::DeserializeOwned;
-use serde::Serialize;
-
 use cosmwasm_std::{StdError, StdResult, Storage};
 
 use crate::snapshot::{ChangeSet, Snapshot};
@@ -9,13 +6,19 @@ use crate::{Item, Map, Strategy};
 /// Item that maintains a snapshot of one or more checkpoints.
 /// We can query historical data as well as current state.
 /// What data is snapshotted depends on the Strategy.
-pub struct SnapshotItem<'a, T> {
+pub struct SnapshotItem<'a, T>
+where
+    T: prost::Message + Default,
+{
     primary: Item<'a, T>,
     changelog_namespace: &'a str,
     snapshots: Snapshot<'a, (), T>,
 }
 
-impl<'a, T> SnapshotItem<'a, T> {
+impl<'a, T> SnapshotItem<'a, T>
+where
+    T: prost::Message + Default,
+{
     /// Example:
     ///
     /// ```rust
@@ -56,7 +59,7 @@ impl<'a, T> SnapshotItem<'a, T> {
 
 impl<'a, T> SnapshotItem<'a, T>
 where
-    T: Serialize + DeserializeOwned + Clone,
+    T: prost::Message + Clone + Default,
 {
     /// load old value and store changelog
     fn write_change(&self, store: &mut dyn Storage, height: u64) -> StdResult<()> {

--- a/src/snapshot/map.rs
+++ b/src/snapshot/map.rs
@@ -30,7 +30,7 @@ where
     /// ```rust
     /// use cw_storage_plus::{SnapshotMap, Strategy};
     ///
-    /// SnapshotMap::<&[u8], &str>::new(
+    /// SnapshotMap::<&[u8], String>::new(
     ///     "never",
     ///     "never__check",
     ///     "never__change",

--- a/src/snapshot/map.rs
+++ b/src/snapshot/map.rs
@@ -1,6 +1,3 @@
-use serde::de::DeserializeOwned;
-use serde::Serialize;
-
 use cosmwasm_std::{StdError, StdResult, Storage};
 
 use crate::bound::PrefixBound;
@@ -16,12 +13,18 @@ use crate::{Bound, Prefixer, Strategy};
 /// Map that maintains a snapshots of one or more checkpoints.
 /// We can query historical data as well as current state.
 /// What data is snapshotted depends on the Strategy.
-pub struct SnapshotMap<'a, K, T> {
+pub struct SnapshotMap<'a, K, T>
+where
+    T: prost::Message + Default,
+{
     primary: Map<'a, K, T>,
     snapshots: Snapshot<'a, K, T>,
 }
 
-impl<'a, K, T> SnapshotMap<'a, K, T> {
+impl<'a, K, T> SnapshotMap<'a, K, T>
+where
+    T: prost::Message + Default,
+{
     /// Example:
     ///
     /// ```rust
@@ -53,7 +56,7 @@ impl<'a, K, T> SnapshotMap<'a, K, T> {
 
 impl<'a, K, T> SnapshotMap<'a, K, T>
 where
-    T: Serialize + DeserializeOwned + Clone,
+    T: prost::Message + Clone + Default,
     K: PrimaryKey<'a> + Prefixer<'a>,
 {
     pub fn add_checkpoint(&self, store: &mut dyn Storage, height: u64) -> StdResult<()> {
@@ -67,7 +70,7 @@ where
 
 impl<'a, K, T> SnapshotMap<'a, K, T>
 where
-    T: Serialize + DeserializeOwned + Clone,
+    T: prost::Message + Clone + Default,
     K: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize,
 {
     pub fn key(&self, k: K) -> Path<T> {
@@ -164,7 +167,7 @@ where
 // short-cut for simple keys, rather than .prefix(()).range_raw(...)
 impl<'a, K, T> SnapshotMap<'a, K, T>
 where
-    T: Serialize + DeserializeOwned + Clone,
+    T: prost::Message + Clone + Default,
     K: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize,
 {
     // I would prefer not to copy code from Prefix, but no other way
@@ -199,7 +202,7 @@ where
 #[cfg(feature = "iterator")]
 impl<'a, K, T> SnapshotMap<'a, K, T>
 where
-    T: Serialize + DeserializeOwned,
+    T: prost::Message + Default,
     K: PrimaryKey<'a> + KeyDeserialize,
 {
     /// While `range` over a `prefix` fixes the prefix to one element and iterates over the

--- a/tests/index_list.rs
+++ b/tests/index_list.rs
@@ -13,7 +13,7 @@ mod test {
             id: u64,
             #[prost(uint32, tag = "2")]
             id2: u32,
-            #[prost(message, tag = "3")]
+            #[prost(message, required, tag = "3")]
             addr: Addr,
         }
 
@@ -40,7 +40,7 @@ mod test {
             id: u64,
             #[prost(uint32, tag = "2")]
             id2: u32,
-            #[prost(message, tag = "3")]
+            #[prost(message, required, tag = "3")]
             addr: Addr,
         }
 

--- a/tests/index_list.rs
+++ b/tests/index_list.rs
@@ -1,16 +1,19 @@
 #[cfg(all(test, feature = "iterator", feature = "macro"))]
 mod test {
+    use cosmwasm_schema::cw_prost;
     use cosmwasm_std::{testing::MockStorage, Addr};
     use cw_storage_macro::index_list;
     use cw_storage_plus::{IndexedMap, MultiIndex, UniqueIndex};
-    use serde::{Deserialize, Serialize};
 
     #[test]
     fn index_list_compiles() {
-        #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+        #[cw_prost]
         struct TestStruct {
+            #[prost(uint64, tag = "1")]
             id: u64,
+            #[prost(uint32, tag = "2")]
             id2: u32,
+            #[prost(message, tag = "3")]
             addr: Addr,
         }
 
@@ -31,10 +34,13 @@ mod test {
 
     #[test]
     fn index_list_works() {
-        #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+        #[cw_prost]
         struct TestStruct {
+            #[prost(uint64, tag = "1")]
             id: u64,
+            #[prost(uint32, tag = "2")]
             id2: u32,
+            #[prost(message, tag = "3")]
             addr: Addr,
         }
 


### PR DESCRIPTION
This makes use of prost support in https://github.com/CosmWasm/cosmwasm/pull/1769 and converts cw_storage_plus to use prost::Message rather than serde json encoding.

This is meant as a demo. It breaks all existing code. Proper usage would be to make this a cw-storage-plus-prost package (or make this a multi-repo). But for now, I am pushing this branch here so @larry0x can play with it and see if there are sufficient improvements.