### PR TITLE
Remove unused to_length_prefixed

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -81,7 +81,7 @@ pub(crate) fn nested_namespaces_with_key(
 }
 
 /// Encodes the length of a given namespace as a 2 byte big endian encoded integer
-pub(crate) fn encode_length(namespace: &[u8]) -> [u8; 2] {
+fn encode_length(namespace: &[u8]) -> [u8; 2] {
     if namespace.len() > 0xFFFF {
         panic!("only supports namespaces up to length 0xFFFF")
     }

--- a/src/iter_helpers.rs
+++ b/src/iter_helpers.rs
@@ -6,7 +6,6 @@ use cosmwasm_std::Record;
 use cosmwasm_std::{from_slice, StdResult};
 
 use crate::de::KeyDeserialize;
-use crate::helpers::encode_length;
 
 #[allow(dead_code)]
 pub(crate) fn deserialize_v<T: DeserializeOwned>(kv: Record) -> StdResult<Record<T>> {
@@ -24,16 +23,6 @@ pub(crate) fn deserialize_kv<K: KeyDeserialize, T: DeserializeOwned>(
     Ok((kt, vt))
 }
 
-/// Calculates the raw key prefix for a given namespace as documented
-/// in https://github.com/webmaster128/key-namespacing#length-prefixed-keys
-#[allow(dead_code)]
-pub(crate) fn to_length_prefixed(namespace: &[u8]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(namespace.len() + 2);
-    out.extend_from_slice(&encode_length(namespace));
-    out.extend_from_slice(namespace);
-    out
-}
-
 // TODO: add a check here that it is the real prefix?
 #[inline]
 pub(crate) fn trim(namespace: &[u8], key: &[u8]) -> Vec<u8> {
@@ -45,60 +34,6 @@ pub(crate) fn concat(namespace: &[u8], key: &[u8]) -> Vec<u8> {
     let mut k = namespace.to_vec();
     k.extend_from_slice(key);
     k
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn to_length_prefixed_works() {
-        assert_eq!(to_length_prefixed(b""), b"\x00\x00");
-        assert_eq!(to_length_prefixed(b"a"), b"\x00\x01a");
-        assert_eq!(to_length_prefixed(b"ab"), b"\x00\x02ab");
-        assert_eq!(to_length_prefixed(b"abc"), b"\x00\x03abc");
-    }
-
-    #[test]
-    fn to_length_prefixed_works_for_long_prefix() {
-        let long_namespace1 = vec![0; 256];
-        let prefix1 = to_length_prefixed(&long_namespace1);
-        assert_eq!(prefix1.len(), 256 + 2);
-        assert_eq!(&prefix1[0..2], b"\x01\x00");
-
-        let long_namespace2 = vec![0; 30000];
-        let prefix2 = to_length_prefixed(&long_namespace2);
-        assert_eq!(prefix2.len(), 30000 + 2);
-        assert_eq!(&prefix2[0..2], b"\x75\x30");
-
-        let long_namespace3 = vec![0; 0xFFFF];
-        let prefix3 = to_length_prefixed(&long_namespace3);
-        assert_eq!(prefix3.len(), 0xFFFF + 2);
-        assert_eq!(&prefix3[0..2], b"\xFF\xFF");
-    }
-
-    #[test]
-    #[should_panic(expected = "only supports namespaces up to length 0xFFFF")]
-    fn to_length_prefixed_panics_for_too_long_prefix() {
-        let limit = 0xFFFF;
-        let long_namespace = vec![0; limit + 1];
-        to_length_prefixed(&long_namespace);
-    }
-
-    #[test]
-    fn to_length_prefixed_calculates_capacity_correctly() {
-        // Those tests cannot guarantee the required capacity was calculated correctly before
-        // the vector allocation but increase the likelyhood of a proper implementation.
-
-        let key = to_length_prefixed(b"");
-        assert_eq!(key.capacity(), key.len());
-
-        let key = to_length_prefixed(b"h");
-        assert_eq!(key.capacity(), key.len());
-
-        let key = to_length_prefixed(b"hij");
-        assert_eq!(key.capacity(), key.len());
-    }
 }
 
 // currently disabled tests as they require a bunch of legacy non-sense


### PR DESCRIPTION
This is now publicly exposed in `cosmwasm_std::storage_keys::to_length_prefixed`