### PR TITLE
Use storage functions from cosmwasm_std::storage_keys

### DIFF
--- a/src/deque.rs
+++ b/src/deque.rs
@@ -1,9 +1,9 @@
 use std::{any::type_name, convert::TryInto, marker::PhantomData};
 
-use cosmwasm_std::{from_json, to_json_vec, StdError, StdResult, Storage};
+use cosmwasm_std::{
+    from_json, storage_keys::namespace_with_key, to_json_vec, StdError, StdResult, Storage,
+};
 use serde::{de::DeserializeOwned, Serialize};
-
-use crate::helpers::namespaces_with_key;
 
 // metadata keys need to have different length than the position type (4 bytes) to prevent collisions
 const TAIL_KEY: &[u8] = b"t";
@@ -130,7 +130,7 @@ impl<'a, T: Serialize + DeserializeOwned> Deque<'a, T> {
 
     /// Helper method for `tail` and `head` methods to handle reading the value from storage
     fn read_meta_key(&self, storage: &dyn Storage, key: &[u8]) -> StdResult<u32> {
-        let full_key = namespaces_with_key(&[self.namespace], key);
+        let full_key = namespace_with_key(&[self.namespace], key);
         storage
             .get(&full_key)
             .map(|vec| {
@@ -146,7 +146,7 @@ impl<'a, T: Serialize + DeserializeOwned> Deque<'a, T> {
     /// Helper method for `set_tail` and `set_head` methods to write to storage
     #[inline]
     fn set_meta_key(&self, storage: &mut dyn Storage, key: &[u8], value: u32) {
-        let full_key = namespaces_with_key(&[self.namespace], key);
+        let full_key = namespace_with_key(&[self.namespace], key);
         storage.set(&full_key, &value.to_be_bytes());
     }
 
@@ -169,7 +169,7 @@ impl<'a, T: Serialize + DeserializeOwned> Deque<'a, T> {
     /// Tries to get the value at the given position
     /// Used internally
     fn get_unchecked(&self, storage: &dyn Storage, pos: u32) -> StdResult<Option<T>> {
-        let prefixed_key = namespaces_with_key(&[self.namespace], &pos.to_be_bytes());
+        let prefixed_key = namespace_with_key(&[self.namespace], &pos.to_be_bytes());
         let value = storage.get(&prefixed_key);
         value.map(|v| from_json(v)).transpose()
     }
@@ -177,14 +177,14 @@ impl<'a, T: Serialize + DeserializeOwned> Deque<'a, T> {
     /// Removes the value at the given position
     /// Used internally
     fn remove_unchecked(&self, storage: &mut dyn Storage, pos: u32) {
-        let prefixed_key = namespaces_with_key(&[self.namespace], &pos.to_be_bytes());
+        let prefixed_key = namespace_with_key(&[self.namespace], &pos.to_be_bytes());
         storage.remove(&prefixed_key);
     }
 
     /// Tries to set the value at the given position
     /// Used internally when pushing
     fn set_unchecked(&self, storage: &mut dyn Storage, pos: u32, value: &T) -> StdResult<()> {
-        let prefixed_key = namespaces_with_key(&[self.namespace], &pos.to_be_bytes());
+        let prefixed_key = namespace_with_key(&[self.namespace], &pos.to_be_bytes());
         storage.set(&prefixed_key, &to_json_vec(value)?);
 
         Ok(())

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -6,57 +6,10 @@
 
 use std::any::type_name;
 
-use crate::keys::Key;
-
 use cosmwasm_std::{
     to_json_vec, Addr, Binary, ContractResult, CustomQuery, QuerierWrapper, QueryRequest, StdError,
     StdResult, SystemResult, WasmQuery,
 };
-
-/// This is equivalent concat(to_length_prefixed_nested(namespaces), key)
-/// But more efficient when the intermediate namespaces often must be recalculated
-pub(crate) fn namespaces_with_key(namespaces: &[&[u8]], key: &[u8]) -> Vec<u8> {
-    let mut size = key.len();
-    for &namespace in namespaces {
-        size += namespace.len() + 2;
-    }
-
-    let mut out = Vec::with_capacity(size);
-    for &namespace in namespaces {
-        out.extend_from_slice(&encode_length(namespace));
-        out.extend_from_slice(namespace);
-    }
-    out.extend_from_slice(key);
-    out
-}
-
-/// Customization of namespaces_with_key for when
-/// there are multiple sets we do not want to combine just to call this
-pub(crate) fn nested_namespaces_with_key(
-    top_names: &[&[u8]],
-    sub_names: &[Key],
-    key: &[u8],
-) -> Vec<u8> {
-    let mut size = key.len();
-    for &namespace in top_names {
-        size += namespace.len() + 2;
-    }
-    for namespace in sub_names {
-        size += namespace.as_ref().len() + 2;
-    }
-
-    let mut out = Vec::with_capacity(size);
-    for &namespace in top_names {
-        out.extend_from_slice(&encode_length(namespace));
-        out.extend_from_slice(namespace);
-    }
-    for namespace in sub_names {
-        out.extend_from_slice(&encode_length(namespace.as_ref()));
-        out.extend_from_slice(namespace.as_ref());
-    }
-    out.extend_from_slice(key);
-    out
-}
 
 /// Encodes the length of a given namespace as a 2 byte big endian encoded integer
 fn encode_length(namespace: &[u8]) -> [u8; 2] {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -11,15 +11,6 @@ use cosmwasm_std::{
     StdResult, SystemResult, WasmQuery,
 };
 
-/// Encodes the length of a given namespace as a 2 byte big endian encoded integer
-fn encode_length(namespace: &[u8]) -> [u8; 2] {
-    if namespace.len() > 0xFFFF {
-        panic!("only supports namespaces up to length 0xFFFF")
-    }
-    let length_bytes = (namespace.len() as u32).to_be_bytes();
-    [length_bytes[2], length_bytes[3]]
-}
-
 /// Use this in Map/SnapshotMap/etc when you want to provide a QueryRaw helper.
 /// This is similar to `querier.query(WasmQuery::Raw {})`, except it does NOT parse the
 /// result, but return a possibly empty Binary to be handled by the calling code.
@@ -67,24 +58,6 @@ mod test {
     struct Person {
         pub name: String,
         pub age: i32,
-    }
-
-    #[test]
-    fn encode_length_works() {
-        assert_eq!(encode_length(b""), *b"\x00\x00");
-        assert_eq!(encode_length(b"a"), *b"\x00\x01");
-        assert_eq!(encode_length(b"aa"), *b"\x00\x02");
-        assert_eq!(encode_length(b"aaa"), *b"\x00\x03");
-        assert_eq!(encode_length(&vec![1; 255]), *b"\x00\xff");
-        assert_eq!(encode_length(&vec![1; 256]), *b"\x01\x00");
-        assert_eq!(encode_length(&vec![1; 12345]), *b"\x30\x39");
-        assert_eq!(encode_length(&vec![1; 65535]), *b"\xff\xff");
-    }
-
-    #[test]
-    #[should_panic(expected = "only supports namespaces up to length 0xFFFF")]
-    fn encode_length_panics_for_large_values() {
-        encode_length(&vec![1; 65536]);
     }
 
     #[test]

--- a/src/indexes/multi.rs
+++ b/src/indexes/multi.rs
@@ -1,6 +1,7 @@
 // this module requires iterator to be useful at all
 #![cfg(feature = "iterator")]
 
+use cosmwasm_std::storage_keys::namespace_with_key;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
@@ -8,7 +9,6 @@ use cosmwasm_std::{from_json, Order, Record, StdError, StdResult, Storage};
 
 use crate::bound::PrefixBound;
 use crate::de::KeyDeserialize;
-use crate::helpers::namespaces_with_key;
 use crate::iter_helpers::deserialize_kv;
 use crate::map::Map;
 use crate::prefix::namespaced_prefix_range;
@@ -93,7 +93,7 @@ fn deserialize_multi_v<T: DeserializeOwned>(
     let offset = key.len() - pk_len as usize;
     let pk = &key[offset..];
 
-    let full_key = namespaces_with_key(&[pk_namespace], pk);
+    let full_key = namespace_with_key(&[pk_namespace], pk);
 
     let v = store
         .get(&full_key)
@@ -117,7 +117,7 @@ fn deserialize_multi_kv<K: KeyDeserialize, T: DeserializeOwned>(
     let offset = key.len() - pk_len as usize;
     let pk = &key[offset..];
 
-    let full_key = namespaces_with_key(&[pk_namespace], pk);
+    let full_key = namespace_with_key(&[pk_namespace], pk);
 
     let v = store
         .get(&full_key)

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,7 +1,6 @@
-use cosmwasm_std::Addr;
+use cosmwasm_std::{storage_keys::namespace_with_key, Addr};
 
 use crate::de::KeyDeserialize;
-use crate::helpers::namespaces_with_key;
 use crate::int_key::IntKey;
 
 #[derive(Debug)]
@@ -69,7 +68,7 @@ pub trait PrimaryKey<'a>: Clone {
     fn joined_key(&self) -> Vec<u8> {
         let keys = self.key();
         let l = keys.len();
-        namespaces_with_key(
+        namespace_with_key(
             &keys[0..l - 1].iter().map(Key::as_ref).collect::<Vec<_>>(),
             keys[l - 1].as_ref(),
         )
@@ -77,7 +76,7 @@ pub trait PrimaryKey<'a>: Clone {
 
     fn joined_extra_key(&self, key: &[u8]) -> Vec<u8> {
         let keys = self.key();
-        namespaces_with_key(&keys.iter().map(Key::as_ref).collect::<Vec<_>>(), key)
+        namespace_with_key(&keys.iter().map(Key::as_ref).collect::<Vec<_>>(), key)
     }
 }
 
@@ -188,7 +187,7 @@ pub trait Prefixer<'a> {
 
     fn joined_prefix(&self) -> Vec<u8> {
         let prefixes = self.prefix();
-        namespaces_with_key(&prefixes.iter().map(Key::as_ref).collect::<Vec<_>>(), &[])
+        namespace_with_key(&prefixes.iter().map(Key::as_ref).collect::<Vec<_>>(), &[])
     }
 }
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,9 +1,9 @@
+use cosmwasm_std::storage_keys::namespace_with_key;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::marker::PhantomData;
 
-use crate::helpers::{nested_namespaces_with_key, not_found_object_info};
-use crate::keys::Key;
+use crate::helpers::not_found_object_info;
 use cosmwasm_std::{from_json, to_json_vec, StdError, StdResult, Storage};
 use std::ops::Deref;
 
@@ -35,15 +35,14 @@ where
 {
     pub fn new(namespace: &[u8], keys: &[&[u8]]) -> Self {
         let l = keys.len();
-        // FIXME: make this more efficient
-        let storage_key = nested_namespaces_with_key(
-            &[namespace],
-            &keys[0..l - 1]
-                .iter()
-                .map(|k| Key::Ref(k))
-                .collect::<Vec<Key>>(),
-            keys[l - 1],
-        );
+
+        // Combine namespace and all but last keys.
+        // This is a single vector allocation with references as elements.
+        let mut combined: Vec<&[u8]> = Vec::with_capacity(1 + keys.len() - 1);
+        combined.push(namespace);
+        combined.extend(keys[0..l - 1].iter());
+        debug_assert_eq!(combined.capacity(), combined.len()); // ensure no reallocation needed
+        let storage_key = namespace_with_key(&combined, keys[l - 1]);
         Path {
             storage_key,
             data: PhantomData,

--- a/src/path.rs
+++ b/src/path.rs
@@ -38,10 +38,11 @@ where
 
         // Combine namespace and all but last keys.
         // This is a single vector allocation with references as elements.
-        let mut combined: Vec<&[u8]> = Vec::with_capacity(1 + keys.len() - 1);
+        let calculated_len = 1 + keys.len() - 1;
+        let mut combined: Vec<&[u8]> = Vec::with_capacity(calculated_len);
         combined.push(namespace);
         combined.extend(keys[0..l - 1].iter());
-        debug_assert_eq!(combined.capacity(), combined.len()); // ensure no reallocation needed
+        debug_assert_eq!(calculated_len, combined.len()); // as long as we calculate correctly, we don't need to reallocate
         let storage_key = namespace_with_key(&combined, keys[l - 1]);
         Path {
             storage_key,

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "iterator")]
 use core::fmt;
+use cosmwasm_std::storage_keys::to_length_prefixed_nested;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::fmt::Debug;
@@ -10,7 +11,6 @@ use std::ops::Deref;
 
 use crate::bound::{PrefixBound, RawBound};
 use crate::de::KeyDeserialize;
-use crate::helpers::{namespaces_with_key, nested_namespaces_with_key};
 use crate::iter_helpers::{concat, deserialize_kv, deserialize_v, trim};
 use crate::keys::Key;
 use crate::{Bound, Prefixer, PrimaryKey};
@@ -98,7 +98,11 @@ where
         de_fn_kv: DeserializeKvFn<K, T>,
         de_fn_v: DeserializeVFn<T>,
     ) -> Self {
-        let storage_prefix = nested_namespaces_with_key(&[top_name], sub_names, b"");
+        let mut combined: Vec<&[u8]> = Vec::with_capacity(1 + sub_names.len());
+        combined.push(top_name);
+        combined.extend(sub_names.iter().map(|sub_name| sub_name.as_ref()));
+        debug_assert_eq!(combined.capacity(), combined.len()); // ensure no reallocation needed
+        let storage_prefix = to_length_prefixed_nested(&combined);
         Prefix {
             storage_prefix,
             data: PhantomData,
@@ -323,7 +327,7 @@ pub fn namespaced_prefix_range<'a, 'c, K: Prefixer<'a>>(
     end: Option<PrefixBound<'a, K>>,
     order: Order,
 ) -> Box<dyn Iterator<Item = Record> + 'c> {
-    let prefix = namespaces_with_key(&[namespace], &[]);
+    let prefix = to_length_prefixed_nested(&[namespace]);
     let start = calc_prefix_start_bound(&prefix, start);
     let end = calc_prefix_end_bound(&prefix, end);
 

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -98,10 +98,11 @@ where
         de_fn_kv: DeserializeKvFn<K, T>,
         de_fn_v: DeserializeVFn<T>,
     ) -> Self {
-        let mut combined: Vec<&[u8]> = Vec::with_capacity(1 + sub_names.len());
+        let calculated_len = 1 + sub_names.len();
+        let mut combined: Vec<&[u8]> = Vec::with_capacity(calculated_len);
         combined.push(top_name);
         combined.extend(sub_names.iter().map(|sub_name| sub_name.as_ref()));
-        debug_assert_eq!(combined.capacity(), combined.len()); // ensure no reallocation needed
+        debug_assert_eq!(calculated_len, combined.len()); // as long as we calculate correctly, we don't need to reallocate
         let storage_prefix = to_length_prefixed_nested(&combined);
         Prefix {
             storage_prefix,


### PR DESCRIPTION
This makes use of the exports from https://github.com/CosmWasm/cosmwasm/pull/1676 to avoid the duplication.

It cannot easily applies to the release/1.2 branch because there the cosmwasm-std requirement is too low. We need 1.4.0 to get the new export.

I'll keep this a draft until #61 is merged to release/1.2 and release/1.2 is merged to main to avoid the duplicated removal of `fn to_length_prefixed`.