### PR TITLE
Remove namespace lifetimes + support owned namespace strings

### DIFF
--- a/src/deque.rs
+++ b/src/deque.rs
@@ -14,15 +14,15 @@ const HEAD_KEY: &[u8] = b"h";
 ///
 /// It has a maximum capacity of `u32::MAX - 1`. Make sure to never exceed that number when using this type.
 /// If you do, the methods won't work as intended anymore.
-pub struct Deque<'a, T> {
+pub struct Deque<T> {
     // prefix of the deque items
-    namespace: &'a [u8],
+    namespace: &'static [u8],
     // see https://doc.rust-lang.org/std/marker/struct.PhantomData.html#unused-type-parameters for why this is needed
     item_type: PhantomData<T>,
 }
 
-impl<'a, T> Deque<'a, T> {
-    pub const fn new(prefix: &'a str) -> Self {
+impl<T> Deque<T> {
+    pub const fn new(prefix: &'static str) -> Self {
         Self {
             namespace: prefix.as_bytes(),
             item_type: PhantomData,
@@ -30,7 +30,7 @@ impl<'a, T> Deque<'a, T> {
     }
 }
 
-impl<'a, T: Serialize + DeserializeOwned> Deque<'a, T> {
+impl<T: Serialize + DeserializeOwned> Deque<T> {
     /// Adds the given value to the end of the deque
     pub fn push_back(&self, storage: &mut dyn Storage, value: &T) -> StdResult<()> {
         // save value
@@ -197,8 +197,8 @@ fn calc_len(head: u32, tail: u32) -> u32 {
     tail.wrapping_sub(head)
 }
 
-impl<'a, T: Serialize + DeserializeOwned> Deque<'a, T> {
-    pub fn iter(&self, storage: &'a dyn Storage) -> StdResult<DequeIter<T>> {
+impl<T: Serialize + DeserializeOwned> Deque<T> {
+    pub fn iter<'a>(&'a self, storage: &'a dyn Storage) -> StdResult<DequeIter<'a, T>> {
         Ok(DequeIter {
             deque: self,
             storage,
@@ -212,7 +212,7 @@ pub struct DequeIter<'a, T>
 where
     T: Serialize + DeserializeOwned,
 {
-    deque: &'a Deque<'a, T>,
+    deque: &'a Deque<T>,
     storage: &'a dyn Storage,
     start: u32,
     end: u32,

--- a/src/deque.rs
+++ b/src/deque.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::{
 };
 use serde::{de::DeserializeOwned, Serialize};
 
-use crate::namespace::Ns;
+use crate::{namespace::Ns, Namespace};
 
 // metadata keys need to have different length than the position type (4 bytes) to prevent collisions
 const TAIL_KEY: &[u8] = b"t";
@@ -35,9 +35,9 @@ impl<T> Deque<T> {
 
     /// Creates a new [`Deque`] with the given storage key. Use this if you might need to handle
     /// a dynamic string. Otherwise, you should probably prefer [`Deque::new`].
-    pub fn new_dyn(prefix: impl Into<Ns>) -> Self {
+    pub fn new_dyn(prefix: impl Namespace) -> Self {
         Self {
-            namespace: prefix.into(),
+            namespace: prefix.namespace(),
             item_type: PhantomData,
         }
     }

--- a/src/deque.rs
+++ b/src/deque.rs
@@ -35,7 +35,7 @@ impl<T> Deque<T> {
 
     /// Creates a new [`Deque`] with the given storage key. Use this if you might need to handle
     /// a dynamic string. Otherwise, you should probably prefer [`Deque::new`].
-    pub fn new_generic(prefix: impl Into<Ns>) -> Self {
+    pub fn new_dyn(prefix: impl Into<Ns>) -> Self {
         Self {
             namespace: prefix.into(),
             item_type: PhantomData,
@@ -316,7 +316,7 @@ mod tests {
 
         for i in 1..4 {
             let key = format!("key{}", i);
-            let item = Deque::new_generic(key);
+            let item = Deque::new_dyn(key);
             for i in 0..i {
                 item.push_back(&mut store, &i).unwrap();
             }

--- a/src/deque.rs
+++ b/src/deque.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::{
 };
 use serde::{de::DeserializeOwned, Serialize};
 
-use crate::namespace::Ns;
+use crate::namespace::Namespace;
 
 // metadata keys need to have different length than the position type (4 bytes) to prevent collisions
 const TAIL_KEY: &[u8] = b"t";
@@ -18,7 +18,7 @@ const HEAD_KEY: &[u8] = b"h";
 /// If you do, the methods won't work as intended anymore.
 pub struct Deque<T> {
     // prefix of the deque items
-    namespace: Ns,
+    namespace: Namespace,
     // see https://doc.rust-lang.org/std/marker/struct.PhantomData.html#unused-type-parameters for why this is needed
     item_type: PhantomData<T>,
 }
@@ -28,14 +28,14 @@ impl<T> Deque<T> {
     /// when you have a prefix in the form of a static string slice.
     pub const fn new(prefix: &'static str) -> Self {
         Self {
-            namespace: Ns::from_static_str(prefix),
+            namespace: Namespace::from_static_str(prefix),
             item_type: PhantomData,
         }
     }
 
     /// Creates a new [`Deque`] with the given storage key. Use this if you might need to handle
     /// a dynamic string. Otherwise, you should probably prefer [`Deque::new`].
-    pub fn new_dyn(prefix: impl Into<Ns>) -> Self {
+    pub fn new_dyn(prefix: impl Into<Namespace>) -> Self {
         Self {
             namespace: prefix.into(),
             item_type: PhantomData,

--- a/src/deque.rs
+++ b/src/deque.rs
@@ -311,6 +311,44 @@ mod tests {
     use serde::{Deserialize, Serialize};
 
     #[test]
+    fn owned_key() {
+        let mut store = MockStorage::new();
+
+        for i in 1..4 {
+            let key = format!("key{}", i);
+            let item = Deque::new_generic(key);
+            for i in 0..i {
+                item.push_back(&mut store, &i).unwrap();
+            }
+        }
+
+        assert_eq!(
+            Deque::<u32>::new("key1")
+                .iter(&store)
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap(),
+            vec![0]
+        );
+        assert_eq!(
+            Deque::<u32>::new("key2")
+                .iter(&store)
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap(),
+            vec![0, 1]
+        );
+        assert_eq!(
+            Deque::<u32>::new("key3")
+                .iter(&store)
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap(),
+            vec![0, 1, 2]
+        );
+    }
+
+    #[test]
     fn push_and_pop() {
         const PEOPLE: Deque<String> = Deque::new("people");
         let mut store = MockStorage::new();

--- a/src/deque.rs
+++ b/src/deque.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::{
 };
 use serde::{de::DeserializeOwned, Serialize};
 
-use crate::{namespace::Ns, Namespace};
+use crate::namespace::Ns;
 
 // metadata keys need to have different length than the position type (4 bytes) to prevent collisions
 const TAIL_KEY: &[u8] = b"t";
@@ -35,9 +35,9 @@ impl<T> Deque<T> {
 
     /// Creates a new [`Deque`] with the given storage key. Use this if you might need to handle
     /// a dynamic string. Otherwise, you should probably prefer [`Deque::new`].
-    pub fn new_dyn(prefix: impl Namespace) -> Self {
+    pub fn new_dyn(prefix: impl Into<Ns>) -> Self {
         Self {
-            namespace: prefix.namespace(),
+            namespace: prefix.into(),
             item_type: PhantomData,
         }
     }

--- a/src/deque.rs
+++ b/src/deque.rs
@@ -143,7 +143,7 @@ impl<T: Serialize + DeserializeOwned> Deque<T> {
 
     /// Helper method for `tail` and `head` methods to handle reading the value from storage
     fn read_meta_key(&self, storage: &dyn Storage, key: &[u8]) -> StdResult<u32> {
-        let full_key = namespace_with_key(&[&self.namespace], key);
+        let full_key = namespace_with_key(&[self.namespace.as_slice()], key);
         storage
             .get(&full_key)
             .map(|vec| {
@@ -159,7 +159,7 @@ impl<T: Serialize + DeserializeOwned> Deque<T> {
     /// Helper method for `set_tail` and `set_head` methods to write to storage
     #[inline]
     fn set_meta_key(&self, storage: &mut dyn Storage, key: &[u8], value: u32) {
-        let full_key = namespace_with_key(&[&self.namespace], key);
+        let full_key = namespace_with_key(&[self.namespace.as_slice()], key);
         storage.set(&full_key, &value.to_be_bytes());
     }
 
@@ -182,7 +182,7 @@ impl<T: Serialize + DeserializeOwned> Deque<T> {
     /// Tries to get the value at the given position
     /// Used internally
     fn get_unchecked(&self, storage: &dyn Storage, pos: u32) -> StdResult<Option<T>> {
-        let prefixed_key = namespace_with_key(&[&self.namespace], &pos.to_be_bytes());
+        let prefixed_key = namespace_with_key(&[self.namespace.as_slice()], &pos.to_be_bytes());
         let value = storage.get(&prefixed_key);
         value.map(|v| from_json(v)).transpose()
     }
@@ -190,14 +190,14 @@ impl<T: Serialize + DeserializeOwned> Deque<T> {
     /// Removes the value at the given position
     /// Used internally
     fn remove_unchecked(&self, storage: &mut dyn Storage, pos: u32) {
-        let prefixed_key = namespace_with_key(&[&self.namespace], &pos.to_be_bytes());
+        let prefixed_key = namespace_with_key(&[self.namespace.as_slice()], &pos.to_be_bytes());
         storage.remove(&prefixed_key);
     }
 
     /// Tries to set the value at the given position
     /// Used internally when pushing
     fn set_unchecked(&self, storage: &mut dyn Storage, pos: u32, value: &T) -> StdResult<()> {
-        let prefixed_key = namespace_with_key(&[&self.namespace], &pos.to_be_bytes());
+        let prefixed_key = namespace_with_key(&[self.namespace.as_slice()], &pos.to_be_bytes());
         storage.set(&prefixed_key, &to_json_vec(value)?);
 
         Ok(())

--- a/src/deque.rs
+++ b/src/deque.rs
@@ -24,6 +24,8 @@ pub struct Deque<T> {
 }
 
 impl<T> Deque<T> {
+    /// Creates a new [`Deque`] with the given storage key. This is a constant function only suitable
+    /// when you have a prefix in the form of a static string slice.
     pub const fn new(prefix: &'static str) -> Self {
         Self {
             namespace: Ns::from_static_str(prefix),
@@ -31,6 +33,8 @@ impl<T> Deque<T> {
         }
     }
 
+    /// Creates a new [`Deque`] with the given storage key. Use this if you might need to handle
+    /// a dynamic string. Otherwise, you should probably prefer [`Deque::new`].
     pub fn new_generic(prefix: impl Into<Ns>) -> Self {
         Self {
             namespace: prefix.into(),

--- a/src/indexed_map.rs
+++ b/src/indexed_map.rs
@@ -26,7 +26,7 @@ where
     I: IndexList<T>,
 {
     pk_namespace: &'a [u8],
-    primary: Map<'a, K, T>,
+    primary: Map<K, T>,
     /// This is meant to be read directly to get the proper types, like:
     /// map.idx.owner.items(...)
     pub idx: I,
@@ -38,7 +38,7 @@ where
     T: Serialize + DeserializeOwned + Clone,
     I: IndexList<T>,
 {
-    pub const fn new(pk_namespace: &'a str, indexes: I) -> Self {
+    pub const fn new(pk_namespace: &'static str, indexes: I) -> Self {
         IndexedMap {
             pk_namespace: pk_namespace.as_bytes(),
             primary: Map::new(pk_namespace),

--- a/src/indexed_map.rs
+++ b/src/indexed_map.rs
@@ -46,12 +46,12 @@ where
 
     /// Creates a new [`IndexedMap`] with the given storage key. Use this if you might need to handle
     /// a dynamic string. Otherwise, you should probably prefer [`IndexedMap::new`].
-    pub fn new_generic(pk_namespace: impl Into<Ns>, indexes: I) -> Self {
+    pub fn new_dyn(pk_namespace: impl Into<Ns>, indexes: I) -> Self {
         let pk_namespace = pk_namespace.into();
 
         IndexedMap {
             pk_namespace: pk_namespace.clone(),
-            primary: Map::new_generic(pk_namespace),
+            primary: Map::new_dyn(pk_namespace),
             idx: indexes,
         }
     }

--- a/src/indexed_map.rs
+++ b/src/indexed_map.rs
@@ -34,6 +34,8 @@ where
     T: Serialize + DeserializeOwned + Clone,
     I: IndexList<T>,
 {
+    /// Creates a new [`IndexedMap`] with the given storage key. This is a constant function only suitable
+    /// when you have a prefix in the form of a static string slice.
     pub const fn new(pk_namespace: &'static str, indexes: I) -> Self {
         IndexedMap {
             pk_namespace: Ns::from_static_str(pk_namespace),
@@ -42,6 +44,8 @@ where
         }
     }
 
+    /// Creates a new [`IndexedMap`] with the given storage key. Use this if you might need to handle
+    /// a dynamic string. Otherwise, you should probably prefer [`IndexedMap::new`].
     pub fn new_generic(pk_namespace: impl Into<Ns>, indexes: I) -> Self {
         let pk_namespace = pk_namespace.into();
 

--- a/src/indexed_map.rs
+++ b/src/indexed_map.rs
@@ -1,7 +1,7 @@
 // this module requires iterator to be useful at all
 #![cfg(feature = "iterator")]
 
-use crate::namespace::Ns;
+use crate::namespace::Namespace;
 use crate::PrefixBound;
 use cosmwasm_std::{StdError, StdResult, Storage};
 use serde::de::DeserializeOwned;
@@ -21,7 +21,7 @@ pub trait IndexList<T> {
 
 /// `IndexedMap` works like a `Map` but has a secondary index
 pub struct IndexedMap<K, T, I> {
-    pk_namespace: Ns,
+    pk_namespace: Namespace,
     primary: Map<K, T>,
     /// This is meant to be read directly to get the proper types, like:
     /// map.idx.owner.items(...)
@@ -38,7 +38,7 @@ where
     /// when you have a prefix in the form of a static string slice.
     pub const fn new(pk_namespace: &'static str, indexes: I) -> Self {
         IndexedMap {
-            pk_namespace: Ns::from_static_str(pk_namespace),
+            pk_namespace: Namespace::from_static_str(pk_namespace),
             primary: Map::new(pk_namespace),
             idx: indexes,
         }
@@ -46,7 +46,7 @@ where
 
     /// Creates a new [`IndexedMap`] with the given storage key. Use this if you might need to handle
     /// a dynamic string. Otherwise, you should probably prefer [`IndexedMap::new`].
-    pub fn new_dyn(pk_namespace: impl Into<Ns>, indexes: I) -> Self {
+    pub fn new_dyn(pk_namespace: impl Into<Namespace>, indexes: I) -> Self {
         let pk_namespace = pk_namespace.into();
 
         IndexedMap {

--- a/src/indexed_map.rs
+++ b/src/indexed_map.rs
@@ -2,7 +2,7 @@
 #![cfg(feature = "iterator")]
 
 use crate::namespace::Ns;
-use crate::PrefixBound;
+use crate::{Namespace, PrefixBound};
 use cosmwasm_std::{StdError, StdResult, Storage};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -46,8 +46,8 @@ where
 
     /// Creates a new [`IndexedMap`] with the given storage key. Use this if you might need to handle
     /// a dynamic string. Otherwise, you should probably prefer [`IndexedMap::new`].
-    pub fn new_dyn(pk_namespace: impl Into<Ns>, indexes: I) -> Self {
-        let pk_namespace = pk_namespace.into();
+    pub fn new_dyn(pk_namespace: impl Namespace, indexes: I) -> Self {
+        let pk_namespace = pk_namespace.namespace();
 
         IndexedMap {
             pk_namespace: pk_namespace.clone(),

--- a/src/indexed_map.rs
+++ b/src/indexed_map.rs
@@ -145,7 +145,7 @@ where
 
     // use no_prefix to scan -> range
     fn no_prefix_raw(&self) -> Prefix<Vec<u8>, T, K> {
-        Prefix::new(&self.pk_namespace, &[])
+        Prefix::new(self.pk_namespace.as_slice(), &[])
     }
 
     /// Clears the map, removing all elements.
@@ -157,7 +157,7 @@ where
             let paths = self
                 .no_prefix_raw()
                 .keys_raw(store, None, None, cosmwasm_std::Order::Ascending)
-                .map(|raw_key| Path::<T>::new(&self.pk_namespace, &[raw_key.as_slice()]))
+                .map(|raw_key| Path::<T>::new(self.pk_namespace.as_slice(), &[raw_key.as_slice()]))
                 // Take just TAKE elements to prevent possible heap overflow if the Map is big.
                 .take(TAKE)
                 .collect::<Vec<_>>();
@@ -200,8 +200,8 @@ where
         T: 'c,
         'a: 'c,
     {
-        let mapped =
-            namespaced_prefix_range(store, &self.pk_namespace, min, max, order).map(deserialize_v);
+        let mapped = namespaced_prefix_range(store, self.pk_namespace.as_slice(), min, max, order)
+            .map(deserialize_v);
         Box::new(mapped)
     }
 }
@@ -214,11 +214,11 @@ where
     I: IndexList<T>,
 {
     pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<K::SuperSuffix, T, K::SuperSuffix> {
-        Prefix::new(&self.pk_namespace, &p.prefix())
+        Prefix::new(self.pk_namespace.as_slice(), &p.prefix())
     }
 
     pub fn prefix(&self, p: K::Prefix) -> Prefix<K::Suffix, T, K::Suffix> {
-        Prefix::new(&self.pk_namespace, &p.prefix())
+        Prefix::new(self.pk_namespace.as_slice(), &p.prefix())
     }
 }
 
@@ -248,7 +248,7 @@ where
         K: 'c,
         K::Output: 'static,
     {
-        let mapped = namespaced_prefix_range(store, &self.pk_namespace, min, max, order)
+        let mapped = namespaced_prefix_range(store, self.pk_namespace.as_slice(), min, max, order)
             .map(deserialize_kv::<K, T>);
         Box::new(mapped)
     }
@@ -305,7 +305,7 @@ where
     }
 
     fn no_prefix(&self) -> Prefix<K, T, K> {
-        Prefix::new(&self.pk_namespace, &[])
+        Prefix::new(self.pk_namespace.as_slice(), &[])
     }
 }
 

--- a/src/indexed_map.rs
+++ b/src/indexed_map.rs
@@ -2,7 +2,7 @@
 #![cfg(feature = "iterator")]
 
 use crate::namespace::Ns;
-use crate::{Namespace, PrefixBound};
+use crate::PrefixBound;
 use cosmwasm_std::{StdError, StdResult, Storage};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -46,8 +46,8 @@ where
 
     /// Creates a new [`IndexedMap`] with the given storage key. Use this if you might need to handle
     /// a dynamic string. Otherwise, you should probably prefer [`IndexedMap::new`].
-    pub fn new_dyn(pk_namespace: impl Namespace, indexes: I) -> Self {
-        let pk_namespace = pk_namespace.namespace();
+    pub fn new_dyn(pk_namespace: impl Into<Ns>, indexes: I) -> Self {
+        let pk_namespace = pk_namespace.into();
 
         IndexedMap {
             pk_namespace: pk_namespace.clone(),

--- a/src/indexed_snapshot.rs
+++ b/src/indexed_snapshot.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use crate::de::KeyDeserialize;
 use crate::iter_helpers::deserialize_kv;
 use crate::keys::{Prefixer, PrimaryKey};
-use crate::namespace::Ns;
+use crate::namespace::Namespace;
 use crate::prefix::{namespaced_prefix_range, Prefix};
 use crate::snapshot::{ChangeSet, SnapshotMap};
 use crate::PrefixBound;
@@ -16,7 +16,7 @@ use crate::{Bound, IndexList, Map, Path, Strategy};
 
 /// `IndexedSnapshotMap` works like a `SnapshotMap` but has a secondary index
 pub struct IndexedSnapshotMap<K, T, I> {
-    pk_namespace: Ns,
+    pk_namespace: Namespace,
     primary: SnapshotMap<K, T>,
     /// This is meant to be read directly to get the proper types, like:
     /// map.idx.owner.items(...)
@@ -46,9 +46,9 @@ impl<K, T, I> IndexedSnapshotMap<K, T, I> {
     /// );
     /// ```
     pub fn new(
-        pk_namespace: impl Into<Ns>,
-        checkpoints: impl Into<Ns>,
-        changelog: impl Into<Ns>,
+        pk_namespace: impl Into<Namespace>,
+        checkpoints: impl Into<Namespace>,
+        changelog: impl Into<Namespace>,
         strategy: Strategy,
         indexes: I,
     ) -> Self {

--- a/src/indexed_snapshot.rs
+++ b/src/indexed_snapshot.rs
@@ -11,8 +11,8 @@ use crate::keys::{Prefixer, PrimaryKey};
 use crate::namespace::Ns;
 use crate::prefix::{namespaced_prefix_range, Prefix};
 use crate::snapshot::{ChangeSet, SnapshotMap};
-use crate::PrefixBound;
 use crate::{Bound, IndexList, Map, Path, Strategy};
+use crate::{Namespace, PrefixBound};
 
 /// `IndexedSnapshotMap` works like a `SnapshotMap` but has a secondary index
 pub struct IndexedSnapshotMap<K, T, I> {
@@ -46,13 +46,13 @@ impl<K, T, I> IndexedSnapshotMap<K, T, I> {
     /// );
     /// ```
     pub fn new(
-        pk_namespace: impl Into<Ns>,
-        checkpoints: impl Into<Ns>,
-        changelog: impl Into<Ns>,
+        pk_namespace: impl Namespace,
+        checkpoints: impl Namespace,
+        changelog: impl Namespace,
         strategy: Strategy,
         indexes: I,
     ) -> Self {
-        let pk_namespace = pk_namespace.into();
+        let pk_namespace = pk_namespace.namespace();
         IndexedSnapshotMap {
             pk_namespace: pk_namespace.clone(),
             primary: SnapshotMap::new_dyn(pk_namespace, checkpoints, changelog, strategy),

--- a/src/indexed_snapshot.rs
+++ b/src/indexed_snapshot.rs
@@ -16,7 +16,7 @@ use crate::{Bound, IndexList, Map, Path, Strategy};
 /// `IndexedSnapshotMap` works like a `SnapshotMap` but has a secondary index
 pub struct IndexedSnapshotMap<'a, K, T, I> {
     pk_namespace: &'a [u8],
-    primary: SnapshotMap<'a, K, T>,
+    primary: SnapshotMap<K, T>,
     /// This is meant to be read directly to get the proper types, like:
     /// map.idx.owner.items(...)
     pub idx: I,
@@ -45,9 +45,9 @@ impl<'a, K, T, I> IndexedSnapshotMap<'a, K, T, I> {
     /// );
     /// ```
     pub fn new(
-        pk_namespace: &'a str,
-        checkpoints: &'a str,
-        changelog: &'a str,
+        pk_namespace: &'static str,
+        checkpoints: &'static str,
+        changelog: &'static str,
         strategy: Strategy,
         indexes: I,
     ) -> Self {
@@ -58,7 +58,7 @@ impl<'a, K, T, I> IndexedSnapshotMap<'a, K, T, I> {
         }
     }
 
-    pub fn changelog(&self) -> &Map<'a, (K, u64), ChangeSet<T>> {
+    pub fn changelog(&self) -> &Map<(K, u64), ChangeSet<T>> {
         self.primary.changelog()
     }
 }

--- a/src/indexed_snapshot.rs
+++ b/src/indexed_snapshot.rs
@@ -183,7 +183,7 @@ where
 
     // use no_prefix to scan -> range
     pub fn no_prefix_raw(&self) -> Prefix<Vec<u8>, T, K> {
-        Prefix::new(&self.pk_namespace, &[])
+        Prefix::new(self.pk_namespace.as_slice(), &[])
     }
 }
 
@@ -228,11 +228,11 @@ where
     I: IndexList<T>,
 {
     pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<K::SuperSuffix, T, K::SuperSuffix> {
-        Prefix::new(&self.pk_namespace, &p.prefix())
+        Prefix::new(self.pk_namespace.as_slice(), &p.prefix())
     }
 
     pub fn prefix(&self, p: K::Prefix) -> Prefix<K::Suffix, T, K::Suffix> {
-        Prefix::new(&self.pk_namespace, &p.prefix())
+        Prefix::new(self.pk_namespace.as_slice(), &p.prefix())
     }
 }
 
@@ -262,7 +262,7 @@ where
         K: 'c,
         K::Output: 'static,
     {
-        let mapped = namespaced_prefix_range(store, &self.pk_namespace, min, max, order)
+        let mapped = namespaced_prefix_range(store, self.pk_namespace.as_slice(), min, max, order)
             .map(deserialize_kv::<K, T>);
         Box::new(mapped)
     }
@@ -296,7 +296,7 @@ where
     }
 
     fn no_prefix(&self) -> Prefix<K, T, K> {
-        Prefix::new(&self.pk_namespace, &[])
+        Prefix::new(self.pk_namespace.as_slice(), &[])
     }
 }
 

--- a/src/indexed_snapshot.rs
+++ b/src/indexed_snapshot.rs
@@ -11,8 +11,8 @@ use crate::keys::{Prefixer, PrimaryKey};
 use crate::namespace::Ns;
 use crate::prefix::{namespaced_prefix_range, Prefix};
 use crate::snapshot::{ChangeSet, SnapshotMap};
+use crate::PrefixBound;
 use crate::{Bound, IndexList, Map, Path, Strategy};
-use crate::{Namespace, PrefixBound};
 
 /// `IndexedSnapshotMap` works like a `SnapshotMap` but has a secondary index
 pub struct IndexedSnapshotMap<K, T, I> {
@@ -46,13 +46,13 @@ impl<K, T, I> IndexedSnapshotMap<K, T, I> {
     /// );
     /// ```
     pub fn new(
-        pk_namespace: impl Namespace,
-        checkpoints: impl Namespace,
-        changelog: impl Namespace,
+        pk_namespace: impl Into<Ns>,
+        checkpoints: impl Into<Ns>,
+        changelog: impl Into<Ns>,
         strategy: Strategy,
         indexes: I,
     ) -> Self {
-        let pk_namespace = pk_namespace.namespace();
+        let pk_namespace = pk_namespace.into();
         IndexedSnapshotMap {
             pk_namespace: pk_namespace.clone(),
             primary: SnapshotMap::new_dyn(pk_namespace, checkpoints, changelog, strategy),

--- a/src/indexed_snapshot.rs
+++ b/src/indexed_snapshot.rs
@@ -55,7 +55,7 @@ impl<K, T, I> IndexedSnapshotMap<K, T, I> {
         let pk_namespace = pk_namespace.into();
         IndexedSnapshotMap {
             pk_namespace: pk_namespace.clone(),
-            primary: SnapshotMap::new_generic(pk_namespace, checkpoints, changelog, strategy),
+            primary: SnapshotMap::new_dyn(pk_namespace, checkpoints, changelog, strategy),
             idx: indexes,
         }
     }

--- a/src/indexed_snapshot.rs
+++ b/src/indexed_snapshot.rs
@@ -8,21 +8,22 @@ use serde::Serialize;
 use crate::de::KeyDeserialize;
 use crate::iter_helpers::deserialize_kv;
 use crate::keys::{Prefixer, PrimaryKey};
+use crate::namespace::Ns;
 use crate::prefix::{namespaced_prefix_range, Prefix};
 use crate::snapshot::{ChangeSet, SnapshotMap};
 use crate::PrefixBound;
 use crate::{Bound, IndexList, Map, Path, Strategy};
 
 /// `IndexedSnapshotMap` works like a `SnapshotMap` but has a secondary index
-pub struct IndexedSnapshotMap<'a, K, T, I> {
-    pk_namespace: &'a [u8],
+pub struct IndexedSnapshotMap<K, T, I> {
+    pk_namespace: Ns,
     primary: SnapshotMap<K, T>,
     /// This is meant to be read directly to get the proper types, like:
     /// map.idx.owner.items(...)
     pub idx: I,
 }
 
-impl<'a, K, T, I> IndexedSnapshotMap<'a, K, T, I> {
+impl<K, T, I> IndexedSnapshotMap<K, T, I> {
     /// Examples:
     ///
     /// ```rust
@@ -45,15 +46,16 @@ impl<'a, K, T, I> IndexedSnapshotMap<'a, K, T, I> {
     /// );
     /// ```
     pub fn new(
-        pk_namespace: &'static str,
-        checkpoints: &'static str,
-        changelog: &'static str,
+        pk_namespace: impl Into<Ns>,
+        checkpoints: impl Into<Ns>,
+        changelog: impl Into<Ns>,
         strategy: Strategy,
         indexes: I,
     ) -> Self {
+        let pk_namespace = pk_namespace.into();
         IndexedSnapshotMap {
-            pk_namespace: pk_namespace.as_bytes(),
-            primary: SnapshotMap::new(pk_namespace, checkpoints, changelog, strategy),
+            pk_namespace: pk_namespace.clone(),
+            primary: SnapshotMap::new_generic(pk_namespace, checkpoints, changelog, strategy),
             idx: indexes,
         }
     }
@@ -63,7 +65,7 @@ impl<'a, K, T, I> IndexedSnapshotMap<'a, K, T, I> {
     }
 }
 
-impl<'a, K, T, I> IndexedSnapshotMap<'a, K, T, I>
+impl<'a, K, T, I> IndexedSnapshotMap<K, T, I>
 where
     T: Serialize + DeserializeOwned + Clone,
     K: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize,
@@ -95,7 +97,7 @@ where
     }
 }
 
-impl<'a, K, T, I> IndexedSnapshotMap<'a, K, T, I>
+impl<'a, K, T, I> IndexedSnapshotMap<K, T, I>
 where
     K: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize,
     T: Serialize + DeserializeOwned + Clone,
@@ -181,12 +183,12 @@ where
 
     // use no_prefix to scan -> range
     pub fn no_prefix_raw(&self) -> Prefix<Vec<u8>, T, K> {
-        Prefix::new(self.pk_namespace, &[])
+        Prefix::new(&self.pk_namespace, &[])
     }
 }
 
 // short-cut for simple keys, rather than .prefix(()).range_raw(...)
-impl<'a, K, T, I> IndexedSnapshotMap<'a, K, T, I>
+impl<'a, K, T, I> IndexedSnapshotMap<K, T, I>
 where
     K: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize,
     T: Serialize + DeserializeOwned + Clone,
@@ -219,23 +221,23 @@ where
 }
 
 #[cfg(feature = "iterator")]
-impl<'a, K, T, I> IndexedSnapshotMap<'a, K, T, I>
+impl<'a, K, T, I> IndexedSnapshotMap<K, T, I>
 where
     T: Serialize + DeserializeOwned + Clone,
     K: PrimaryKey<'a>,
     I: IndexList<T>,
 {
     pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<K::SuperSuffix, T, K::SuperSuffix> {
-        Prefix::new(self.pk_namespace, &p.prefix())
+        Prefix::new(&self.pk_namespace, &p.prefix())
     }
 
     pub fn prefix(&self, p: K::Prefix) -> Prefix<K::Suffix, T, K::Suffix> {
-        Prefix::new(self.pk_namespace, &p.prefix())
+        Prefix::new(&self.pk_namespace, &p.prefix())
     }
 }
 
 #[cfg(feature = "iterator")]
-impl<'a, K, T, I> IndexedSnapshotMap<'a, K, T, I>
+impl<'a, K, T, I> IndexedSnapshotMap<K, T, I>
 where
     T: Serialize + DeserializeOwned + Clone,
     K: PrimaryKey<'a> + KeyDeserialize,
@@ -260,7 +262,7 @@ where
         K: 'c,
         K::Output: 'static,
     {
-        let mapped = namespaced_prefix_range(store, self.pk_namespace, min, max, order)
+        let mapped = namespaced_prefix_range(store, &self.pk_namespace, min, max, order)
             .map(deserialize_kv::<K, T>);
         Box::new(mapped)
     }
@@ -294,7 +296,7 @@ where
     }
 
     fn no_prefix(&self) -> Prefix<K, T, K> {
-        Prefix::new(self.pk_namespace, &[])
+        Prefix::new(&self.pk_namespace, &[])
     }
 }
 
@@ -345,7 +347,7 @@ mod test {
     }
 
     // Can we make it easier to define this? (less wordy generic)
-    fn build_snapshot_map<'a>() -> IndexedSnapshotMap<'a, &'a str, Data, DataIndexes<'a>> {
+    fn build_snapshot_map<'a>() -> IndexedSnapshotMap<&'a str, Data, DataIndexes<'a>> {
         let indexes = DataIndexes {
             name: MultiIndex::new(|_pk, d| d.name.as_bytes().to_vec(), "data", "data__name"),
             age: UniqueIndex::new(|d| d.age, "data__age"),
@@ -365,7 +367,7 @@ mod test {
 
     fn save_data<'a>(
         store: &mut MockStorage,
-        map: &IndexedSnapshotMap<'a, &'a str, Data, DataIndexes<'a>>,
+        map: &IndexedSnapshotMap<&'a str, Data, DataIndexes<'a>>,
     ) -> (Vec<&'a str>, Vec<Data>) {
         let mut pks = vec![];
         let mut datas = vec![];

--- a/src/indexes/multi.rs
+++ b/src/indexes/multi.rs
@@ -31,7 +31,7 @@ pub struct MultiIndex<'a, IK, T, PK> {
     index: fn(&[u8], &T) -> IK,
     idx_namespace: &'a [u8],
     // note, we collapse the ik - combining everything under the namespace - and concatenating the pk
-    idx_map: Map<'a, Vec<u8>, u32>,
+    idx_map: Map<Vec<u8>, u32>,
     pk_namespace: &'a [u8],
     phantom: PhantomData<PK>,
 }
@@ -67,7 +67,7 @@ where
     pub const fn new(
         idx_fn: fn(&[u8], &T) -> IK,
         pk_namespace: &'a str,
-        idx_namespace: &'a str,
+        idx_namespace: &'static str,
     ) -> Self {
         MultiIndex {
             index: idx_fn,

--- a/src/indexes/unique.rs
+++ b/src/indexes/unique.rs
@@ -28,7 +28,7 @@ pub(crate) struct UniqueRef<T> {
 /// The PK type defines the type of Primary Key deserialization.
 pub struct UniqueIndex<'a, IK, T, PK> {
     index: fn(&T) -> IK,
-    idx_map: Map<'a, IK, UniqueRef<T>>,
+    idx_map: Map<IK, UniqueRef<T>>,
     idx_namespace: &'a [u8],
     phantom: PhantomData<PK>,
 }
@@ -51,7 +51,7 @@ impl<'a, IK, T, PK> UniqueIndex<'a, IK, T, PK> {
     ///
     /// UniqueIndex::<_, _, ()>::new(|d: &Data| d.age, "data__age");
     /// ```
-    pub const fn new(idx_fn: fn(&T) -> IK, idx_namespace: &'a str) -> Self {
+    pub const fn new(idx_fn: fn(&T) -> IK, idx_namespace: &'static str) -> Self {
         UniqueIndex {
             index: idx_fn,
             idx_map: Map::new(idx_namespace),

--- a/src/item.rs
+++ b/src/item.rs
@@ -45,25 +45,25 @@ where
 {
     // this gets the path of the data to use elsewhere
     pub fn as_slice(&self) -> &[u8] {
-        &self.storage_key
+        self.storage_key.as_slice()
     }
 
     /// save will serialize the model and store, returns an error on serialization issues
     pub fn save(&self, store: &mut dyn Storage, data: &T) -> StdResult<()> {
-        store.set(&self.storage_key, &to_json_vec(data)?);
+        store.set(self.storage_key.as_slice(), &to_json_vec(data)?);
         Ok(())
     }
 
     pub fn remove(&self, store: &mut dyn Storage) {
-        store.remove(&self.storage_key);
+        store.remove(self.storage_key.as_slice());
     }
 
     /// load will return an error if no data is set at the given key, or on parse error
     pub fn load(&self, store: &dyn Storage) -> StdResult<T> {
-        if let Some(value) = store.get(&self.storage_key) {
+        if let Some(value) = store.get(self.storage_key.as_slice()) {
             from_json(value)
         } else {
-            let object_info = not_found_object_info::<T>(&self.storage_key);
+            let object_info = not_found_object_info::<T>(self.storage_key.as_slice());
             Err(StdError::not_found(object_info))
         }
     }
@@ -71,13 +71,13 @@ where
     /// may_load will parse the data stored at the key if present, returns `Ok(None)` if no data there.
     /// returns an error on issues parsing
     pub fn may_load(&self, store: &dyn Storage) -> StdResult<Option<T>> {
-        let value = store.get(&self.storage_key);
+        let value = store.get(self.storage_key.as_slice());
         value.map(|v| from_json(v)).transpose()
     }
 
     /// Returns `true` if data is stored at the key, `false` otherwise.
     pub fn exists(&self, store: &dyn Storage) -> bool {
-        store.get(&self.storage_key).is_some()
+        store.get(self.storage_key.as_slice()).is_some()
     }
 
     /// Loads the data, perform the specified action, and store the result
@@ -107,7 +107,7 @@ where
     ) -> StdResult<T> {
         let request = WasmQuery::Raw {
             contract_addr: remote_contract.into(),
-            key: (&*self.storage_key).into(),
+            key: (self.storage_key.as_slice()).into(),
         };
         querier.query(&request.into())
     }

--- a/src/item.rs
+++ b/src/item.rs
@@ -12,15 +12,15 @@ use crate::helpers::not_found_object_info;
 /// Item stores one typed item at the given key.
 /// This is an analog of Singleton.
 /// It functions the same way as Path does but doesn't use a Vec and thus has a const fn constructor.
-pub struct Item<'a, T> {
+pub struct Item<T> {
     // this is full key - no need to length-prefix it, we only store one item
-    storage_key: &'a [u8],
+    storage_key: &'static [u8],
     // see https://doc.rust-lang.org/std/marker/struct.PhantomData.html#unused-type-parameters for why this is needed
     data_type: PhantomData<T>,
 }
 
-impl<'a, T> Item<'a, T> {
-    pub const fn new(storage_key: &'a str) -> Self {
+impl<T> Item<T> {
+    pub const fn new(storage_key: &'static str) -> Self {
         Item {
             storage_key: storage_key.as_bytes(),
             data_type: PhantomData,
@@ -28,7 +28,7 @@ impl<'a, T> Item<'a, T> {
     }
 }
 
-impl<'a, T> Item<'a, T>
+impl<T> Item<T>
 where
     T: Serialize + DeserializeOwned,
 {

--- a/src/item.rs
+++ b/src/item.rs
@@ -7,7 +7,7 @@ use cosmwasm_std::{
     WasmQuery,
 };
 
-use crate::{helpers::not_found_object_info, namespace::Ns, Namespace};
+use crate::{helpers::not_found_object_info, namespace::Ns};
 
 /// Item stores one typed item at the given key.
 /// This is an analog of Singleton.
@@ -31,9 +31,9 @@ impl<T> Item<T> {
 
     /// Creates a new [`Item`] with the given storage key. Use this if you might need to handle
     /// a dynamic string. Otherwise, you might prefer [`Item::new`].
-    pub fn new_dyn(storage_key: impl Namespace) -> Self {
+    pub fn new_dyn(storage_key: impl Into<Ns>) -> Self {
         Item {
-            storage_key: storage_key.namespace(),
+            storage_key: storage_key.into(),
             data_type: PhantomData,
         }
     }

--- a/src/item.rs
+++ b/src/item.rs
@@ -7,14 +7,14 @@ use cosmwasm_std::{
     WasmQuery,
 };
 
-use crate::{helpers::not_found_object_info, namespace::Ns};
+use crate::{helpers::not_found_object_info, namespace::Namespace};
 
 /// Item stores one typed item at the given key.
 /// This is an analog of Singleton.
 /// It functions the same way as Path does but doesn't use a Vec and thus has a const fn constructor.
 pub struct Item<T> {
     // this is full key - no need to length-prefix it, we only store one item
-    storage_key: Ns,
+    storage_key: Namespace,
     // see https://doc.rust-lang.org/std/marker/struct.PhantomData.html#unused-type-parameters for why this is needed
     data_type: PhantomData<T>,
 }
@@ -24,14 +24,14 @@ impl<T> Item<T> {
     /// when you have a static string slice.
     pub const fn new(storage_key: &'static str) -> Self {
         Item {
-            storage_key: Ns::from_static_str(storage_key),
+            storage_key: Namespace::from_static_str(storage_key),
             data_type: PhantomData,
         }
     }
 
     /// Creates a new [`Item`] with the given storage key. Use this if you might need to handle
     /// a dynamic string. Otherwise, you might prefer [`Item::new`].
-    pub fn new_dyn(storage_key: impl Into<Ns>) -> Self {
+    pub fn new_dyn(storage_key: impl Into<Namespace>) -> Self {
         Item {
             storage_key: storage_key.into(),
             data_type: PhantomData,

--- a/src/item.rs
+++ b/src/item.rs
@@ -20,7 +20,7 @@ pub struct Item<T> {
 }
 
 impl<T> Item<T> {
-    /// Creates a new Item with the given storage key. This is a const fn only suitable
+    /// Creates a new [`Item`] with the given storage key. This is a const fn only suitable
     /// when you have a static string slice.
     pub const fn new(storage_key: &'static str) -> Self {
         Item {
@@ -29,8 +29,8 @@ impl<T> Item<T> {
         }
     }
 
-    /// Creates a new Item with the given storage key. Use this if you might need to handle
-    /// a dynamic string. Otherwise, you might like to prefer the const constructor.
+    /// Creates a new [`Item`] with the given storage key. Use this if you might need to handle
+    /// a dynamic string. Otherwise, you might prefer [`Item::new`].
     pub fn new_generic(storage_key: impl Into<Ns>) -> Self {
         Item {
             storage_key: storage_key.into(),

--- a/src/item.rs
+++ b/src/item.rs
@@ -31,7 +31,7 @@ impl<T> Item<T> {
 
     /// Creates a new [`Item`] with the given storage key. Use this if you might need to handle
     /// a dynamic string. Otherwise, you might prefer [`Item::new`].
-    pub fn new_generic(storage_key: impl Into<Ns>) -> Self {
+    pub fn new_dyn(storage_key: impl Into<Ns>) -> Self {
         Item {
             storage_key: storage_key.into(),
             data_type: PhantomData,
@@ -152,7 +152,7 @@ mod test {
 
         for i in 0..3 {
             let key = format!("key{}", i);
-            let item = Item::new_generic(key);
+            let item = Item::new_dyn(key);
             item.save(&mut store, &i).unwrap();
         }
 

--- a/src/item.rs
+++ b/src/item.rs
@@ -7,7 +7,7 @@ use cosmwasm_std::{
     WasmQuery,
 };
 
-use crate::{helpers::not_found_object_info, namespace::Ns};
+use crate::{helpers::not_found_object_info, namespace::Ns, Namespace};
 
 /// Item stores one typed item at the given key.
 /// This is an analog of Singleton.
@@ -31,9 +31,9 @@ impl<T> Item<T> {
 
     /// Creates a new [`Item`] with the given storage key. Use this if you might need to handle
     /// a dynamic string. Otherwise, you might prefer [`Item::new`].
-    pub fn new_dyn(storage_key: impl Into<Ns>) -> Self {
+    pub fn new_dyn(storage_key: impl Namespace) -> Self {
         Item {
-            storage_key: storage_key.into(),
+            storage_key: storage_key.namespace(),
             data_type: PhantomData,
         }
     }

--- a/src/item.rs
+++ b/src/item.rs
@@ -147,6 +147,21 @@ mod test {
     }
 
     #[test]
+    fn owned_key_works() {
+        let mut store = MockStorage::new();
+
+        for i in 0..3 {
+            let key = format!("key{}", i);
+            let item = Item::new_generic(key);
+            item.save(&mut store, &i).unwrap();
+        }
+
+        assert_eq!(store.get(b"key0").unwrap(), b"0");
+        assert_eq!(store.get(b"key1").unwrap(), b"1");
+        assert_eq!(store.get(b"key2").unwrap(), b"2");
+    }
+
+    #[test]
     fn exists_works() {
         let mut store = MockStorage::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub use int_key::IntKey;
 pub use item::Item;
 pub use keys::{Key, Prefixer, PrimaryKey};
 pub use map::Map;
-pub use namespace::Ns;
+pub use namespace::Namespace;
 pub use path::Path;
 #[cfg(feature = "iterator")]
 pub use prefix::{range_with_prefix, Prefix};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub use int_key::IntKey;
 pub use item::Item;
 pub use keys::{Key, Prefixer, PrimaryKey};
 pub use map::Map;
-pub use namespace::Namespace;
+pub use namespace::Ns;
 pub use path::Path;
 #[cfg(feature = "iterator")]
 pub use prefix::{range_with_prefix, Prefix};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub use int_key::IntKey;
 pub use item::Item;
 pub use keys::{Key, Prefixer, PrimaryKey};
 pub use map::Map;
+pub use namespace::Ns;
 pub use path::Path;
 #[cfg(feature = "iterator")]
 pub use prefix::{range_with_prefix, Prefix};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ mod item;
 mod iter_helpers;
 mod keys;
 mod map;
+mod namespace;
 mod path;
 mod prefix;
 mod snapshot;

--- a/src/map.rs
+++ b/src/map.rs
@@ -12,7 +12,7 @@ use crate::iter_helpers::{deserialize_kv, deserialize_v};
 #[cfg(feature = "iterator")]
 use crate::keys::Prefixer;
 use crate::keys::{Key, PrimaryKey};
-use crate::namespace::Ns;
+use crate::namespace::Namespace;
 use crate::path::Path;
 #[cfg(feature = "iterator")]
 use crate::prefix::{namespaced_prefix_range, Prefix};
@@ -22,7 +22,7 @@ use cosmwasm_std::{from_json, Addr, CustomQuery, QuerierWrapper, StdError, StdRe
 
 #[derive(Debug, Clone)]
 pub struct Map<K, T> {
-    namespace: Ns,
+    namespace: Namespace,
     // see https://doc.rust-lang.org/std/marker/struct.PhantomData.html#unused-type-parameters for why this is needed
     key_type: PhantomData<K>,
     data_type: PhantomData<T>,
@@ -33,7 +33,7 @@ impl<K, T> Map<K, T> {
     /// when you have the storage key in the form of a static string slice.
     pub const fn new(namespace: &'static str) -> Self {
         Map {
-            namespace: Ns::from_static_str(namespace),
+            namespace: Namespace::from_static_str(namespace),
             data_type: PhantomData,
             key_type: PhantomData,
         }
@@ -41,7 +41,7 @@ impl<K, T> Map<K, T> {
 
     /// Creates a new [`Map`] with the given storage key. Use this if you might need to handle
     /// a dynamic string. Otherwise, you might prefer [`Map::new`].
-    pub fn new_dyn(namespace: impl Into<Ns>) -> Self {
+    pub fn new_dyn(namespace: impl Into<Namespace>) -> Self {
         Map {
             namespace: namespace.into(),
             data_type: PhantomData,

--- a/src/map.rs
+++ b/src/map.rs
@@ -50,7 +50,7 @@ impl<K, T> Map<K, T> {
     }
 
     pub fn namespace(&self) -> &[u8] {
-        &self.namespace
+        self.namespace.as_slice()
     }
 }
 
@@ -61,14 +61,14 @@ where
 {
     pub fn key(&self, k: K) -> Path<T> {
         Path::new(
-            &self.namespace,
+            self.namespace.as_slice(),
             &k.key().iter().map(Key::as_ref).collect::<Vec<_>>(),
         )
     }
 
     #[cfg(feature = "iterator")]
     pub(crate) fn no_prefix_raw(&self) -> Prefix<Vec<u8>, T, K> {
-        Prefix::new(&self.namespace, &[])
+        Prefix::new(self.namespace.as_slice(), &[])
     }
 
     pub fn save(&self, store: &mut dyn Storage, k: K, data: &T) -> StdResult<()> {
@@ -145,11 +145,11 @@ where
     K: PrimaryKey<'a>,
 {
     pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<K::SuperSuffix, T, K::SuperSuffix> {
-        Prefix::new(&self.namespace, &p.prefix())
+        Prefix::new(self.namespace.as_slice(), &p.prefix())
     }
 
     pub fn prefix(&self, p: K::Prefix) -> Prefix<K::Suffix, T, K::Suffix> {
-        Prefix::new(&self.namespace, &p.prefix())
+        Prefix::new(self.namespace.as_slice(), &p.prefix())
     }
 }
 
@@ -178,8 +178,8 @@ where
         T: 'c,
         'a: 'c,
     {
-        let mapped =
-            namespaced_prefix_range(store, &self.namespace, min, max, order).map(deserialize_v);
+        let mapped = namespaced_prefix_range(store, self.namespace.as_slice(), min, max, order)
+            .map(deserialize_v);
         Box::new(mapped)
     }
 }
@@ -209,13 +209,13 @@ where
         K: 'c,
         K::Output: 'static,
     {
-        let mapped = namespaced_prefix_range(store, &self.namespace, min, max, order)
+        let mapped = namespaced_prefix_range(store, self.namespace.as_slice(), min, max, order)
             .map(deserialize_kv::<K, T>);
         Box::new(mapped)
     }
 
     fn no_prefix(&self) -> Prefix<K, T, K> {
-        Prefix::new(&self.namespace, &[])
+        Prefix::new(self.namespace.as_slice(), &[])
     }
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -16,6 +16,7 @@ use crate::namespace::Ns;
 use crate::path::Path;
 #[cfg(feature = "iterator")]
 use crate::prefix::{namespaced_prefix_range, Prefix};
+use crate::Namespace;
 #[cfg(feature = "iterator")]
 use cosmwasm_std::Order;
 use cosmwasm_std::{from_json, Addr, CustomQuery, QuerierWrapper, StdError, StdResult, Storage};
@@ -41,9 +42,9 @@ impl<K, T> Map<K, T> {
 
     /// Creates a new [`Map`] with the given storage key. Use this if you might need to handle
     /// a dynamic string. Otherwise, you might prefer [`Map::new`].
-    pub fn new_dyn(namespace: impl Into<Ns>) -> Self {
+    pub fn new_dyn(namespace: impl Namespace) -> Self {
         Map {
-            namespace: namespace.into(),
+            namespace: namespace.namespace(),
             data_type: PhantomData,
             key_type: PhantomData,
         }

--- a/src/map.rs
+++ b/src/map.rs
@@ -41,7 +41,7 @@ impl<K, T> Map<K, T> {
 
     /// Creates a new [`Map`] with the given storage key. Use this if you might need to handle
     /// a dynamic string. Otherwise, you might prefer [`Map::new`].
-    pub fn new_generic(namespace: impl Into<Ns>) -> Self {
+    pub fn new_dyn(namespace: impl Into<Ns>) -> Self {
         Map {
             namespace: namespace.into(),
             data_type: PhantomData,

--- a/src/map.rs
+++ b/src/map.rs
@@ -20,15 +20,15 @@ use cosmwasm_std::Order;
 use cosmwasm_std::{from_json, Addr, CustomQuery, QuerierWrapper, StdError, StdResult, Storage};
 
 #[derive(Debug, Clone)]
-pub struct Map<'a, K, T> {
-    namespace: &'a [u8],
+pub struct Map<K, T> {
+    namespace: &'static [u8],
     // see https://doc.rust-lang.org/std/marker/struct.PhantomData.html#unused-type-parameters for why this is needed
     key_type: PhantomData<K>,
     data_type: PhantomData<T>,
 }
 
-impl<'a, K, T> Map<'a, K, T> {
-    pub const fn new(namespace: &'a str) -> Self {
+impl<K, T> Map<K, T> {
+    pub const fn new(namespace: &'static str) -> Self {
         Map {
             namespace: namespace.as_bytes(),
             data_type: PhantomData,
@@ -36,12 +36,12 @@ impl<'a, K, T> Map<'a, K, T> {
         }
     }
 
-    pub fn namespace(&self) -> &'a [u8] {
+    pub fn namespace(&self) -> &'static [u8] {
         self.namespace
     }
 }
 
-impl<'a, K, T> Map<'a, K, T>
+impl<'a, K, T> Map<K, T>
 where
     T: Serialize + DeserializeOwned,
     K: PrimaryKey<'a>,
@@ -126,7 +126,7 @@ where
 }
 
 #[cfg(feature = "iterator")]
-impl<'a, K, T> Map<'a, K, T>
+impl<'a, K, T> Map<K, T>
 where
     T: Serialize + DeserializeOwned,
     K: PrimaryKey<'a>,
@@ -142,7 +142,7 @@ where
 
 // short-cut for simple keys, rather than .prefix(()).range_raw(...)
 #[cfg(feature = "iterator")]
-impl<'a, K, T> Map<'a, K, T>
+impl<'a, K, T> Map<K, T>
 where
     T: Serialize + DeserializeOwned,
     // TODO: this should only be when K::Prefix == ()
@@ -172,7 +172,7 @@ where
 }
 
 #[cfg(feature = "iterator")]
-impl<'a, K, T> Map<'a, K, T>
+impl<'a, K, T> Map<K, T>
 where
     T: Serialize + DeserializeOwned,
     K: PrimaryKey<'a> + KeyDeserialize,
@@ -207,7 +207,7 @@ where
 }
 
 #[cfg(feature = "iterator")]
-impl<'a, K, T> Map<'a, K, T>
+impl<'a, K, T> Map<K, T>
 where
     T: Serialize + DeserializeOwned,
     K: PrimaryKey<'a>,
@@ -240,7 +240,7 @@ where
 }
 
 #[cfg(feature = "iterator")]
-impl<'a, K, T> Map<'a, K, T>
+impl<'a, K, T> Map<K, T>
 where
     T: Serialize + DeserializeOwned,
     K: PrimaryKey<'a> + KeyDeserialize,

--- a/src/map.rs
+++ b/src/map.rs
@@ -16,7 +16,6 @@ use crate::namespace::Ns;
 use crate::path::Path;
 #[cfg(feature = "iterator")]
 use crate::prefix::{namespaced_prefix_range, Prefix};
-use crate::Namespace;
 #[cfg(feature = "iterator")]
 use cosmwasm_std::Order;
 use cosmwasm_std::{from_json, Addr, CustomQuery, QuerierWrapper, StdError, StdResult, Storage};
@@ -42,9 +41,9 @@ impl<K, T> Map<K, T> {
 
     /// Creates a new [`Map`] with the given storage key. Use this if you might need to handle
     /// a dynamic string. Otherwise, you might prefer [`Map::new`].
-    pub fn new_dyn(namespace: impl Namespace) -> Self {
+    pub fn new_dyn(namespace: impl Into<Ns>) -> Self {
         Map {
-            namespace: namespace.namespace(),
+            namespace: namespace.into(),
             data_type: PhantomData,
             key_type: PhantomData,
         }

--- a/src/map.rs
+++ b/src/map.rs
@@ -29,6 +29,8 @@ pub struct Map<K, T> {
 }
 
 impl<K, T> Map<K, T> {
+    /// Creates a new [`Map`] with the given storage key. This is a const fn only suitable
+    /// when you have the storage key in the form of a static string slice.
     pub const fn new(namespace: &'static str) -> Self {
         Map {
             namespace: Ns::from_static_str(namespace),
@@ -37,6 +39,8 @@ impl<K, T> Map<K, T> {
         }
     }
 
+    /// Creates a new [`Map`] with the given storage key. Use this if you might need to handle
+    /// a dynamic string. Otherwise, you might prefer [`Map::new`].
     pub fn new_generic(namespace: impl Into<Ns>) -> Self {
         Map {
             namespace: namespace.into(),

--- a/src/map.rs
+++ b/src/map.rs
@@ -50,7 +50,7 @@ impl<K, T> Map<K, T> {
         }
     }
 
-    pub fn namespace(&self) -> &[u8] {
+    pub fn namespace_bytes(&self) -> &[u8] {
         self.namespace.as_slice()
     }
 }

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -6,11 +6,11 @@ use std::borrow::Cow;
 /// documentation purposes. Most of the time, you should just pass a [`String`] or
 /// `&'static str` to an [`Item`](crate::Item)/collection constructor.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct Ns(Cow<'static, [u8]>);
+pub struct Namespace(Cow<'static, [u8]>);
 
-impl Ns {
-    pub const fn from_static_str(s: &'static str) -> Ns {
-        Ns(Cow::Borrowed(s.as_bytes()))
+impl Namespace {
+    pub const fn from_static_str(s: &'static str) -> Namespace {
+        Namespace(Cow::Borrowed(s.as_bytes()))
     }
 
     pub fn as_slice(&self) -> &[u8] {
@@ -18,20 +18,20 @@ impl Ns {
     }
 }
 
-impl From<&'static str> for Ns {
+impl From<&'static str> for Namespace {
     fn from(s: &'static str) -> Self {
-        Ns(Cow::Borrowed(s.as_bytes()))
+        Namespace(Cow::Borrowed(s.as_bytes()))
     }
 }
 
-impl From<String> for Ns {
+impl From<String> for Namespace {
     fn from(s: String) -> Self {
-        Ns(Cow::Owned(s.into_bytes()))
+        Namespace(Cow::Owned(s.into_bytes()))
     }
 }
 
-impl From<Cow<'static, [u8]>> for Ns {
+impl From<Cow<'static, [u8]>> for Namespace {
     fn from(s: Cow<'static, [u8]>) -> Self {
-        Ns(s)
+        Namespace(s)
     }
 }

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,38 +1,37 @@
 use std::borrow::Cow;
 
-/// Types that can be used as top-level storage keys for storage items and collections.
-pub trait Namespace {
-    fn namespace(self) -> Ns;
-}
-
-impl Namespace for Ns {
-    fn namespace(self) -> Ns {
-        self
-    }
-}
-
-impl Namespace for &'static str {
-    fn namespace(self) -> Ns {
-        Ns::from_static_str(self)
-    }
-}
-
-impl Namespace for String {
-    fn namespace(self) -> Ns {
-        Ns(Cow::Owned(self.into_bytes()))
-    }
-}
-
-/// The namespace of a storage container.
+/// The namespace of a storage container. Meant to be constructed from "stringy" types.
+///
+/// This type is generally not meant to be constructed directly. It's exported for
+/// documentation purposes. Most of the time, you should just pass a [`String`] or
+/// `&'static str` to an [`Item`](crate::Item)/collection constructor.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Ns(Cow<'static, [u8]>);
 
 impl Ns {
-    pub(crate) const fn from_static_str(s: &'static str) -> Ns {
+    pub const fn from_static_str(s: &'static str) -> Ns {
         Ns(Cow::Borrowed(s.as_bytes()))
     }
 
     pub fn as_slice(&self) -> &[u8] {
         self.0.as_ref()
+    }
+}
+
+impl From<&'static str> for Ns {
+    fn from(s: &'static str) -> Self {
+        Ns(Cow::Borrowed(s.as_bytes()))
+    }
+}
+
+impl From<String> for Ns {
+    fn from(s: String) -> Self {
+        Ns(Cow::Owned(s.into_bytes()))
+    }
+}
+
+impl From<Cow<'static, [u8]>> for Ns {
+    fn from(s: Cow<'static, [u8]>) -> Self {
+        Ns(s)
     }
 }

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-/// Types that can be used as namespace designators for storage.
+/// Types that can be used as top-level storage keys for storage items and collections.
 pub trait Namespace {
     fn namespace(self) -> Ns;
 }

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,5 +1,7 @@
 use std::{borrow::Cow, ops::Deref};
 
+/// The namespace of a storage container. This is just convenience internal type
+/// to remove a little recurrent boilerplate.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Ns(Cow<'static, [u8]>);
 

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,0 +1,30 @@
+use std::{borrow::Cow, ops::Deref};
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Ns(Cow<'static, [u8]>);
+
+impl Ns {
+    pub const fn from_static_str(s: &'static str) -> Ns {
+        Ns(Cow::Borrowed(s.as_bytes()))
+    }
+}
+
+impl From<&'static str> for Ns {
+    fn from(s: &'static str) -> Self {
+        Ns(Cow::Borrowed(s.as_bytes()))
+    }
+}
+
+impl From<String> for Ns {
+    fn from(s: String) -> Self {
+        Ns(Cow::Owned(s.into_bytes()))
+    }
+}
+
+impl Deref for Ns {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.0
+    }
+}

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, ops::Deref};
+use std::borrow::Cow;
 
 /// The namespace of a storage container. Meant to be constructed from "stringy" types.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -7,6 +7,10 @@ pub struct Ns(Cow<'static, [u8]>);
 impl Ns {
     pub const fn from_static_str(s: &'static str) -> Ns {
         Ns(Cow::Borrowed(s.as_bytes()))
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        self.0.as_ref()
     }
 }
 
@@ -25,13 +29,5 @@ impl From<String> for Ns {
 impl From<Cow<'static, [u8]>> for Ns {
     fn from(s: Cow<'static, [u8]>) -> Self {
         Ns(s)
-    }
-}
-
-impl Deref for Ns {
-    type Target = [u8];
-
-    fn deref(&self) -> &[u8] {
-        &self.0
     }
 }

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,33 +1,38 @@
 use std::borrow::Cow;
 
-/// The namespace of a storage container. Meant to be constructed from "stringy" types.
+/// Types that can be used as namespace designators for storage.
+pub trait Namespace {
+    fn namespace(self) -> Ns;
+}
+
+impl Namespace for Ns {
+    fn namespace(self) -> Ns {
+        self
+    }
+}
+
+impl Namespace for &'static str {
+    fn namespace(self) -> Ns {
+        Ns::from_static_str(self)
+    }
+}
+
+impl Namespace for String {
+    fn namespace(self) -> Ns {
+        Ns(Cow::Owned(self.into_bytes()))
+    }
+}
+
+/// The namespace of a storage container.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Ns(Cow<'static, [u8]>);
 
 impl Ns {
-    pub const fn from_static_str(s: &'static str) -> Ns {
+    pub(crate) const fn from_static_str(s: &'static str) -> Ns {
         Ns(Cow::Borrowed(s.as_bytes()))
     }
 
     pub fn as_slice(&self) -> &[u8] {
         self.0.as_ref()
-    }
-}
-
-impl From<&'static str> for Ns {
-    fn from(s: &'static str) -> Self {
-        Ns(Cow::Borrowed(s.as_bytes()))
-    }
-}
-
-impl From<String> for Ns {
-    fn from(s: String) -> Self {
-        Ns(Cow::Owned(s.into_bytes()))
-    }
-}
-
-impl From<Cow<'static, [u8]>> for Ns {
-    fn from(s: Cow<'static, [u8]>) -> Self {
-        Ns(s)
     }
 }

--- a/src/namespace.rs
+++ b/src/namespace.rs
@@ -1,7 +1,6 @@
 use std::{borrow::Cow, ops::Deref};
 
-/// The namespace of a storage container. This is just convenience internal type
-/// to remove a little recurrent boilerplate.
+/// The namespace of a storage container. Meant to be constructed from "stringy" types.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Ns(Cow<'static, [u8]>);
 
@@ -20,6 +19,12 @@ impl From<&'static str> for Ns {
 impl From<String> for Ns {
     fn from(s: String) -> Self {
         Ns(Cow::Owned(s.into_bytes()))
+    }
+}
+
+impl From<Cow<'static, [u8]>> for Ns {
+    fn from(s: Cow<'static, [u8]>) -> Self {
+        Ns(s)
     }
 }
 

--- a/src/snapshot/item.rs
+++ b/src/snapshot/item.rs
@@ -48,7 +48,7 @@ impl<T> SnapshotItem<T> {
     /// Creates a new [`SnapshotItem`] with the given storage keys and strategy.
     /// Use this if you might need to handle dynamic strings. Otherwise, you might
     /// prefer [`SnapshotItem::new`].
-    pub fn new_generic(
+    pub fn new_dyn(
         storage_key: impl Into<Ns>,
         checkpoints: impl Into<Ns>,
         changelog: impl Into<Ns>,
@@ -56,7 +56,7 @@ impl<T> SnapshotItem<T> {
     ) -> Self {
         let changelog = changelog.into();
         SnapshotItem {
-            primary: Item::new_generic(storage_key),
+            primary: Item::new_dyn(storage_key),
             changelog_namespace: changelog.clone(),
             snapshots: Snapshot::new_generic(checkpoints, changelog, strategy),
         }
@@ -72,7 +72,7 @@ impl<T> SnapshotItem<T> {
 
     pub fn changelog(&self) -> Map<u64, ChangeSet<T>> {
         // Build and return a compatible Map with the proper key type
-        Map::new_generic(self.changelog_namespace.clone())
+        Map::new_dyn(self.changelog_namespace.clone())
     }
 }
 

--- a/src/snapshot/item.rs
+++ b/src/snapshot/item.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 
 use cosmwasm_std::{StdError, StdResult, Storage};
 
-use crate::namespace::Ns;
+use crate::namespace::Namespace;
 use crate::snapshot::{ChangeSet, Snapshot};
 use crate::{Item, Map, Strategy};
 
@@ -12,7 +12,7 @@ use crate::{Item, Map, Strategy};
 /// What data is snapshotted depends on the Strategy.
 pub struct SnapshotItem<T> {
     primary: Item<T>,
-    changelog_namespace: Ns,
+    changelog_namespace: Namespace,
     snapshots: Snapshot<(), T>,
 }
 
@@ -40,7 +40,7 @@ impl<T> SnapshotItem<T> {
     ) -> Self {
         SnapshotItem {
             primary: Item::new(storage_key),
-            changelog_namespace: Ns::from_static_str(changelog),
+            changelog_namespace: Namespace::from_static_str(changelog),
             snapshots: Snapshot::new(checkpoints, changelog, strategy),
         }
     }
@@ -49,9 +49,9 @@ impl<T> SnapshotItem<T> {
     /// Use this if you might need to handle dynamic strings. Otherwise, you might
     /// prefer [`SnapshotItem::new`].
     pub fn new_dyn(
-        storage_key: impl Into<Ns>,
-        checkpoints: impl Into<Ns>,
-        changelog: impl Into<Ns>,
+        storage_key: impl Into<Namespace>,
+        checkpoints: impl Into<Namespace>,
+        changelog: impl Into<Namespace>,
         strategy: Strategy,
     ) -> Self {
         let changelog = changelog.into();

--- a/src/snapshot/item.rs
+++ b/src/snapshot/item.rs
@@ -9,13 +9,13 @@ use crate::{Item, Map, Strategy};
 /// Item that maintains a snapshot of one or more checkpoints.
 /// We can query historical data as well as current state.
 /// What data is snapshotted depends on the Strategy.
-pub struct SnapshotItem<'a, T> {
-    primary: Item<'a, T>,
-    changelog_namespace: &'a str,
-    snapshots: Snapshot<'a, (), T>,
+pub struct SnapshotItem<T> {
+    primary: Item<T>,
+    changelog_namespace: &'static str,
+    snapshots: Snapshot<(), T>,
 }
 
-impl<'a, T> SnapshotItem<'a, T> {
+impl<T> SnapshotItem<T> {
     /// Example:
     ///
     /// ```rust
@@ -28,9 +28,9 @@ impl<'a, T> SnapshotItem<'a, T> {
     ///     Strategy::EveryBlock);
     /// ```
     pub const fn new(
-        storage_key: &'a str,
-        checkpoints: &'a str,
-        changelog: &'a str,
+        storage_key: &'static str,
+        checkpoints: &'static str,
+        changelog: &'static str,
         strategy: Strategy,
     ) -> Self {
         SnapshotItem {
@@ -54,7 +54,7 @@ impl<'a, T> SnapshotItem<'a, T> {
     }
 }
 
-impl<'a, T> SnapshotItem<'a, T>
+impl<T> SnapshotItem<T>
 where
     T: Serialize + DeserializeOwned + Clone,
 {
@@ -135,7 +135,7 @@ mod tests {
     use crate::bound::Bound;
     use cosmwasm_std::testing::MockStorage;
 
-    type TestItem = SnapshotItem<'static, u64>;
+    type TestItem = SnapshotItem<u64>;
 
     const NEVER: TestItem =
         SnapshotItem::new("never", "never__check", "never__change", Strategy::Never);

--- a/src/snapshot/item.rs
+++ b/src/snapshot/item.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::{StdError, StdResult, Storage};
 
 use crate::namespace::Ns;
 use crate::snapshot::{ChangeSet, Snapshot};
-use crate::{Item, Map, Strategy};
+use crate::{Item, Map, Namespace, Strategy};
 
 /// Item that maintains a snapshot of one or more checkpoints.
 /// We can query historical data as well as current state.
@@ -49,16 +49,16 @@ impl<T> SnapshotItem<T> {
     /// Use this if you might need to handle dynamic strings. Otherwise, you might
     /// prefer [`SnapshotItem::new`].
     pub fn new_dyn(
-        storage_key: impl Into<Ns>,
-        checkpoints: impl Into<Ns>,
-        changelog: impl Into<Ns>,
+        storage_key: impl Namespace,
+        checkpoints: impl Namespace,
+        changelog: impl Namespace,
         strategy: Strategy,
     ) -> Self {
-        let changelog = changelog.into();
+        let changelog = changelog.namespace();
         SnapshotItem {
             primary: Item::new_dyn(storage_key),
             changelog_namespace: changelog.clone(),
-            snapshots: Snapshot::new_generic(checkpoints, changelog, strategy),
+            snapshots: Snapshot::new_dyn(checkpoints, changelog, strategy),
         }
     }
 

--- a/src/snapshot/item.rs
+++ b/src/snapshot/item.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::{StdError, StdResult, Storage};
 
 use crate::namespace::Ns;
 use crate::snapshot::{ChangeSet, Snapshot};
-use crate::{Item, Map, Namespace, Strategy};
+use crate::{Item, Map, Strategy};
 
 /// Item that maintains a snapshot of one or more checkpoints.
 /// We can query historical data as well as current state.
@@ -49,16 +49,16 @@ impl<T> SnapshotItem<T> {
     /// Use this if you might need to handle dynamic strings. Otherwise, you might
     /// prefer [`SnapshotItem::new`].
     pub fn new_dyn(
-        storage_key: impl Namespace,
-        checkpoints: impl Namespace,
-        changelog: impl Namespace,
+        storage_key: impl Into<Ns>,
+        checkpoints: impl Into<Ns>,
+        changelog: impl Into<Ns>,
         strategy: Strategy,
     ) -> Self {
-        let changelog = changelog.namespace();
+        let changelog = changelog.into();
         SnapshotItem {
             primary: Item::new_dyn(storage_key),
             changelog_namespace: changelog.clone(),
-            snapshots: Snapshot::new_dyn(checkpoints, changelog, strategy),
+            snapshots: Snapshot::new_generic(checkpoints, changelog, strategy),
         }
     }
 

--- a/src/snapshot/item.rs
+++ b/src/snapshot/item.rs
@@ -48,6 +48,22 @@ impl<T> SnapshotItem<T> {
     /// Creates a new [`SnapshotItem`] with the given storage keys and strategy.
     /// Use this if you might need to handle dynamic strings. Otherwise, you might
     /// prefer [`SnapshotItem::new`].
+    ///
+    /// Example:
+    ///
+    /// ```rust
+    /// use cw_storage_plus::{SnapshotItem, Strategy};
+    ///
+    /// let key = "every";
+    /// let checkpoints_key = format!("{}_check", key);
+    /// let changelog_key = format!("{}_change", key);
+    ///
+    /// SnapshotItem::<u64>::new_dyn(
+    ///     key,
+    ///     checkpoints_key,
+    ///     changelog_key,
+    ///     Strategy::EveryBlock);
+    /// ```
     pub fn new_dyn(
         storage_key: impl Into<Namespace>,
         checkpoints: impl Into<Namespace>,
@@ -58,7 +74,7 @@ impl<T> SnapshotItem<T> {
         SnapshotItem {
             primary: Item::new_dyn(storage_key),
             changelog_namespace: changelog.clone(),
-            snapshots: Snapshot::new_generic(checkpoints, changelog, strategy),
+            snapshots: Snapshot::new_dyn(checkpoints, changelog, strategy),
         }
     }
 

--- a/src/snapshot/item.rs
+++ b/src/snapshot/item.rs
@@ -17,6 +17,10 @@ pub struct SnapshotItem<T> {
 }
 
 impl<T> SnapshotItem<T> {
+    /// Creates a new [`SnapshotItem`] with the given storage keys and strategy.
+    /// This is a const fn only suitable when all the storage keys provided are
+    /// static strings.
+    ///
     /// Example:
     ///
     /// ```rust
@@ -41,6 +45,9 @@ impl<T> SnapshotItem<T> {
         }
     }
 
+    /// Creates a new [`SnapshotItem`] with the given storage keys and strategy.
+    /// Use this if you might need to handle dynamic strings. Otherwise, you might
+    /// prefer [`SnapshotItem::new`].
     pub fn new_generic(
         storage_key: impl Into<Ns>,
         checkpoints: impl Into<Ns>,

--- a/src/snapshot/item.rs
+++ b/src/snapshot/item.rs
@@ -21,7 +21,7 @@ impl<T> SnapshotItem<T> {
     /// ```rust
     /// use cw_storage_plus::{SnapshotItem, Strategy};
     ///
-    /// SnapshotItem::<'static, u64>::new(
+    /// SnapshotItem::<u64>::new(
     ///     "every",
     ///     "every__check",
     ///     "every__change",

--- a/src/snapshot/map.rs
+++ b/src/snapshot/map.rs
@@ -8,7 +8,7 @@ use crate::de::KeyDeserialize;
 use crate::iter_helpers::deserialize_kv;
 use crate::keys::PrimaryKey;
 use crate::map::Map;
-use crate::namespace::Ns;
+use crate::namespace::Namespace;
 use crate::path::Path;
 use crate::prefix::{namespaced_prefix_range, Prefix};
 use crate::snapshot::{ChangeSet, Snapshot};
@@ -55,9 +55,9 @@ impl<K, T> SnapshotMap<K, T> {
     /// Use this if you might need to handle dynamic strings. Otherwise, you might
     /// prefer [`SnapshotMap::new`].
     pub fn new_dyn(
-        pk: impl Into<Ns>,
-        checkpoints: impl Into<Ns>,
-        changelog: impl Into<Ns>,
+        pk: impl Into<Namespace>,
+        checkpoints: impl Into<Namespace>,
+        changelog: impl Into<Namespace>,
         strategy: Strategy,
     ) -> Self {
         SnapshotMap {

--- a/src/snapshot/map.rs
+++ b/src/snapshot/map.rs
@@ -54,14 +54,14 @@ impl<K, T> SnapshotMap<K, T> {
     /// Creates a new [`SnapshotMap`] with the given storage keys and strategy.
     /// Use this if you might need to handle dynamic strings. Otherwise, you might
     /// prefer [`SnapshotMap::new`].
-    pub fn new_generic(
+    pub fn new_dyn(
         pk: impl Into<Ns>,
         checkpoints: impl Into<Ns>,
         changelog: impl Into<Ns>,
         strategy: Strategy,
     ) -> Self {
         SnapshotMap {
-            primary: Map::new_generic(pk),
+            primary: Map::new_dyn(pk),
             snapshots: Snapshot::new_generic(checkpoints, changelog, strategy),
         }
     }

--- a/src/snapshot/map.rs
+++ b/src/snapshot/map.rs
@@ -23,6 +23,10 @@ pub struct SnapshotMap<K, T> {
 }
 
 impl<K, T> SnapshotMap<K, T> {
+    /// Creates a new [`SnapshotMap`] with the given storage keys and strategy.
+    /// This is a const fn only suitable when all the storage keys provided are
+    /// static strings.
+    ///
     /// Example:
     ///
     /// ```rust
@@ -47,6 +51,9 @@ impl<K, T> SnapshotMap<K, T> {
         }
     }
 
+    /// Creates a new [`SnapshotMap`] with the given storage keys and strategy.
+    /// Use this if you might need to handle dynamic strings. Otherwise, you might
+    /// prefer [`SnapshotMap::new`].
     pub fn new_generic(
         pk: impl Into<Ns>,
         checkpoints: impl Into<Ns>,

--- a/src/snapshot/map.rs
+++ b/src/snapshot/map.rs
@@ -8,10 +8,11 @@ use crate::de::KeyDeserialize;
 use crate::iter_helpers::deserialize_kv;
 use crate::keys::PrimaryKey;
 use crate::map::Map;
+use crate::namespace::Ns;
 use crate::path::Path;
 use crate::prefix::{namespaced_prefix_range, Prefix};
 use crate::snapshot::{ChangeSet, Snapshot};
-use crate::{Bound, Namespace, Prefixer, Strategy};
+use crate::{Bound, Prefixer, Strategy};
 
 /// Map that maintains a snapshots of one or more checkpoints.
 /// We can query historical data as well as current state.
@@ -54,14 +55,14 @@ impl<K, T> SnapshotMap<K, T> {
     /// Use this if you might need to handle dynamic strings. Otherwise, you might
     /// prefer [`SnapshotMap::new`].
     pub fn new_dyn(
-        pk: impl Namespace,
-        checkpoints: impl Namespace,
-        changelog: impl Namespace,
+        pk: impl Into<Ns>,
+        checkpoints: impl Into<Ns>,
+        changelog: impl Into<Ns>,
         strategy: Strategy,
     ) -> Self {
         SnapshotMap {
             primary: Map::new_dyn(pk),
-            snapshots: Snapshot::new_dyn(checkpoints, changelog, strategy),
+            snapshots: Snapshot::new_generic(checkpoints, changelog, strategy),
         }
     }
 

--- a/src/snapshot/map.rs
+++ b/src/snapshot/map.rs
@@ -8,6 +8,7 @@ use crate::de::KeyDeserialize;
 use crate::iter_helpers::deserialize_kv;
 use crate::keys::PrimaryKey;
 use crate::map::Map;
+use crate::namespace::Ns;
 use crate::path::Path;
 use crate::prefix::{namespaced_prefix_range, Prefix};
 use crate::snapshot::{ChangeSet, Snapshot};
@@ -43,6 +44,18 @@ impl<K, T> SnapshotMap<K, T> {
         SnapshotMap {
             primary: Map::new(pk),
             snapshots: Snapshot::new(checkpoints, changelog, strategy),
+        }
+    }
+
+    pub fn new_generic(
+        pk: impl Into<Ns>,
+        checkpoints: impl Into<Ns>,
+        changelog: impl Into<Ns>,
+        strategy: Strategy,
+    ) -> Self {
+        SnapshotMap {
+            primary: Map::new_generic(pk),
+            snapshots: Snapshot::new_generic(checkpoints, changelog, strategy),
         }
     }
 

--- a/src/snapshot/map.rs
+++ b/src/snapshot/map.rs
@@ -240,8 +240,9 @@ where
         K: 'c,
         K::Output: 'static,
     {
-        let mapped = namespaced_prefix_range(store, self.primary.namespace(), min, max, order)
-            .map(deserialize_kv::<K, T>);
+        let mapped =
+            namespaced_prefix_range(store, self.primary.namespace_bytes(), min, max, order)
+                .map(deserialize_kv::<K, T>);
         Box::new(mapped)
     }
 
@@ -274,15 +275,15 @@ where
     }
 
     pub fn prefix(&self, p: K::Prefix) -> Prefix<K::Suffix, T, K::Suffix> {
-        Prefix::new(self.primary.namespace(), &p.prefix())
+        Prefix::new(self.primary.namespace_bytes(), &p.prefix())
     }
 
     pub fn sub_prefix(&self, p: K::SubPrefix) -> Prefix<K::SuperSuffix, T, K::SuperSuffix> {
-        Prefix::new(self.primary.namespace(), &p.prefix())
+        Prefix::new(self.primary.namespace_bytes(), &p.prefix())
     }
 
     fn no_prefix(&self) -> Prefix<K, T, K> {
-        Prefix::new(self.primary.namespace(), &[])
+        Prefix::new(self.primary.namespace_bytes(), &[])
     }
 }
 

--- a/src/snapshot/map.rs
+++ b/src/snapshot/map.rs
@@ -8,11 +8,10 @@ use crate::de::KeyDeserialize;
 use crate::iter_helpers::deserialize_kv;
 use crate::keys::PrimaryKey;
 use crate::map::Map;
-use crate::namespace::Ns;
 use crate::path::Path;
 use crate::prefix::{namespaced_prefix_range, Prefix};
 use crate::snapshot::{ChangeSet, Snapshot};
-use crate::{Bound, Prefixer, Strategy};
+use crate::{Bound, Namespace, Prefixer, Strategy};
 
 /// Map that maintains a snapshots of one or more checkpoints.
 /// We can query historical data as well as current state.
@@ -55,14 +54,14 @@ impl<K, T> SnapshotMap<K, T> {
     /// Use this if you might need to handle dynamic strings. Otherwise, you might
     /// prefer [`SnapshotMap::new`].
     pub fn new_dyn(
-        pk: impl Into<Ns>,
-        checkpoints: impl Into<Ns>,
-        changelog: impl Into<Ns>,
+        pk: impl Namespace,
+        checkpoints: impl Namespace,
+        changelog: impl Namespace,
         strategy: Strategy,
     ) -> Self {
         SnapshotMap {
             primary: Map::new_dyn(pk),
-            snapshots: Snapshot::new_generic(checkpoints, changelog, strategy),
+            snapshots: Snapshot::new_dyn(checkpoints, changelog, strategy),
         }
     }
 

--- a/src/snapshot/map.rs
+++ b/src/snapshot/map.rs
@@ -16,12 +16,12 @@ use crate::{Bound, Prefixer, Strategy};
 /// Map that maintains a snapshots of one or more checkpoints.
 /// We can query historical data as well as current state.
 /// What data is snapshotted depends on the Strategy.
-pub struct SnapshotMap<'a, K, T> {
-    primary: Map<'a, K, T>,
-    snapshots: Snapshot<'a, K, T>,
+pub struct SnapshotMap<K, T> {
+    primary: Map<K, T>,
+    snapshots: Snapshot<K, T>,
 }
 
-impl<'a, K, T> SnapshotMap<'a, K, T> {
+impl<K, T> SnapshotMap<K, T> {
     /// Example:
     ///
     /// ```rust
@@ -35,9 +35,9 @@ impl<'a, K, T> SnapshotMap<'a, K, T> {
     /// );
     /// ```
     pub const fn new(
-        pk: &'a str,
-        checkpoints: &'a str,
-        changelog: &'a str,
+        pk: &'static str,
+        checkpoints: &'static str,
+        changelog: &'static str,
         strategy: Strategy,
     ) -> Self {
         SnapshotMap {
@@ -46,12 +46,12 @@ impl<'a, K, T> SnapshotMap<'a, K, T> {
         }
     }
 
-    pub fn changelog(&self) -> &Map<'a, (K, u64), ChangeSet<T>> {
+    pub fn changelog(&self) -> &Map<(K, u64), ChangeSet<T>> {
         &self.snapshots.changelog
     }
 }
 
-impl<'a, K, T> SnapshotMap<'a, K, T>
+impl<'a, K, T> SnapshotMap<K, T>
 where
     T: Serialize + DeserializeOwned + Clone,
     K: PrimaryKey<'a> + Prefixer<'a>,
@@ -65,7 +65,7 @@ where
     }
 }
 
-impl<'a, K, T> SnapshotMap<'a, K, T>
+impl<'a, K, T> SnapshotMap<K, T>
 where
     T: Serialize + DeserializeOwned + Clone,
     K: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize,
@@ -162,7 +162,7 @@ where
 }
 
 // short-cut for simple keys, rather than .prefix(()).range_raw(...)
-impl<'a, K, T> SnapshotMap<'a, K, T>
+impl<'a, K, T> SnapshotMap<K, T>
 where
     T: Serialize + DeserializeOwned + Clone,
     K: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize,
@@ -197,7 +197,7 @@ where
 }
 
 #[cfg(feature = "iterator")]
-impl<'a, K, T> SnapshotMap<'a, K, T>
+impl<'a, K, T> SnapshotMap<K, T>
 where
     T: Serialize + DeserializeOwned,
     K: PrimaryKey<'a> + KeyDeserialize,
@@ -272,8 +272,8 @@ mod tests {
     use super::*;
     use cosmwasm_std::testing::MockStorage;
 
-    type TestMap = SnapshotMap<'static, &'static str, u64>;
-    type TestMapCompositeKey = SnapshotMap<'static, (&'static str, &'static str), u64>;
+    type TestMap = SnapshotMap<&'static str, u64>;
+    type TestMapCompositeKey = SnapshotMap<(&'static str, &'static str), u64>;
 
     const NEVER: TestMap =
         SnapshotMap::new("never", "never__check", "never__change", Strategy::Never);

--- a/src/snapshot/map.rs
+++ b/src/snapshot/map.rs
@@ -54,6 +54,22 @@ impl<K, T> SnapshotMap<K, T> {
     /// Creates a new [`SnapshotMap`] with the given storage keys and strategy.
     /// Use this if you might need to handle dynamic strings. Otherwise, you might
     /// prefer [`SnapshotMap::new`].
+    ///
+    /// Example:
+    ///
+    /// ```rust
+    /// use cw_storage_plus::{SnapshotMap, Strategy};
+    ///
+    /// let key = "every";
+    /// let checkpoints_key = format!("{}_check", key);
+    /// let changelog_key = format!("{}_change", key);
+    ///
+    /// SnapshotMap::<&[u8], &str>::new_dyn(
+    ///     key,
+    ///     checkpoints_key,
+    ///     changelog_key,
+    ///     Strategy::EveryBlock);
+    /// ```
     pub fn new_dyn(
         pk: impl Into<Namespace>,
         checkpoints: impl Into<Namespace>,
@@ -62,7 +78,7 @@ impl<K, T> SnapshotMap<K, T> {
     ) -> Self {
         SnapshotMap {
             primary: Map::new_dyn(pk),
-            snapshots: Snapshot::new_generic(checkpoints, changelog, strategy),
+            snapshots: Snapshot::new_dyn(checkpoints, changelog, strategy),
         }
     }
 

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -7,8 +7,7 @@ pub use map::SnapshotMap;
 
 use crate::bound::Bound;
 use crate::de::KeyDeserialize;
-use crate::namespace::Ns;
-use crate::{Map, Prefixer, PrimaryKey};
+use crate::{Map, Namespace, Prefixer, PrimaryKey};
 use cosmwasm_std::{Order, StdError, StdResult, Storage};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -48,9 +47,9 @@ impl<K, T> Snapshot<K, T> {
     /// Creates a new [`Snapshot`] with the given storage keys and strategy.
     /// Use this if you might need to handle dynamic strings. Otherwise, you might
     /// prefer [`Snapshot::new`].
-    pub fn new_generic(
-        checkpoints: impl Into<Ns>,
-        changelog: impl Into<Ns>,
+    pub fn new_dyn(
+        checkpoints: impl Namespace,
+        changelog: impl Namespace,
         strategy: Strategy,
     ) -> Snapshot<K, T> {
         Snapshot {

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -54,8 +54,8 @@ impl<K, T> Snapshot<K, T> {
         strategy: Strategy,
     ) -> Snapshot<K, T> {
         Snapshot {
-            checkpoints: Map::new_generic(checkpoints),
-            changelog: Map::new_generic(changelog),
+            checkpoints: Map::new_dyn(checkpoints),
+            changelog: Map::new_dyn(changelog),
             strategy,
         }
     }

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -17,23 +17,23 @@ use serde::{Deserialize, Serialize};
 /// been checkpointed (as u32).
 /// Stores all changes in changelog.
 #[derive(Debug, Clone)]
-pub(crate) struct Snapshot<'a, K, T> {
-    checkpoints: Map<'a, u64, u32>,
+pub(crate) struct Snapshot<K, T> {
+    checkpoints: Map<u64, u32>,
 
     // this stores all changes (key, height). Must differentiate between no data written,
     // and explicit None (just inserted)
-    pub changelog: Map<'a, (K, u64), ChangeSet<T>>,
+    pub changelog: Map<(K, u64), ChangeSet<T>>,
 
     // How aggressive we are about checkpointing all data
     strategy: Strategy,
 }
 
-impl<'a, K, T> Snapshot<'a, K, T> {
+impl<'a, K, T> Snapshot<K, T> {
     pub const fn new(
-        checkpoints: &'a str,
-        changelog: &'a str,
+        checkpoints: &'static str,
+        changelog: &'static str,
         strategy: Strategy,
-    ) -> Snapshot<'a, K, T> {
+    ) -> Snapshot<K, T> {
         Snapshot {
             checkpoints: Map::new(checkpoints),
             changelog: Map::new(changelog),
@@ -61,7 +61,7 @@ impl<'a, K, T> Snapshot<'a, K, T> {
     }
 }
 
-impl<'a, K, T> Snapshot<'a, K, T>
+impl<'a, K, T> Snapshot<K, T>
 where
     T: Serialize + DeserializeOwned + Clone,
     K: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize,
@@ -182,7 +182,7 @@ mod tests {
     use super::*;
     use cosmwasm_std::testing::MockStorage;
 
-    type TestSnapshot = Snapshot<'static, &'static str, u64>;
+    type TestSnapshot = Snapshot<&'static str, u64>;
 
     const NEVER: TestSnapshot = Snapshot::new("never__check", "never__change", Strategy::Never);
     const EVERY: TestSnapshot =

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -48,7 +48,7 @@ impl<K, T> Snapshot<K, T> {
     /// Creates a new [`Snapshot`] with the given storage keys and strategy.
     /// Use this if you might need to handle dynamic strings. Otherwise, you might
     /// prefer [`Snapshot::new`].
-    pub fn new_generic(
+    pub fn new_dyn(
         checkpoints: impl Into<Namespace>,
         changelog: impl Into<Namespace>,
         strategy: Strategy,

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -7,7 +7,8 @@ pub use map::SnapshotMap;
 
 use crate::bound::Bound;
 use crate::de::KeyDeserialize;
-use crate::{Map, Namespace, Prefixer, PrimaryKey};
+use crate::namespace::Ns;
+use crate::{Map, Prefixer, PrimaryKey};
 use cosmwasm_std::{Order, StdError, StdResult, Storage};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -47,9 +48,9 @@ impl<K, T> Snapshot<K, T> {
     /// Creates a new [`Snapshot`] with the given storage keys and strategy.
     /// Use this if you might need to handle dynamic strings. Otherwise, you might
     /// prefer [`Snapshot::new`].
-    pub fn new_dyn(
-        checkpoints: impl Namespace,
-        changelog: impl Namespace,
+    pub fn new_generic(
+        checkpoints: impl Into<Ns>,
+        changelog: impl Into<Ns>,
         strategy: Strategy,
     ) -> Snapshot<K, T> {
         Snapshot {

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -7,6 +7,7 @@ pub use map::SnapshotMap;
 
 use crate::bound::Bound;
 use crate::de::KeyDeserialize;
+use crate::namespace::Ns;
 use crate::{Map, Prefixer, PrimaryKey};
 use cosmwasm_std::{Order, StdError, StdResult, Storage};
 use serde::de::DeserializeOwned;
@@ -28,7 +29,7 @@ pub(crate) struct Snapshot<K, T> {
     strategy: Strategy,
 }
 
-impl<'a, K, T> Snapshot<K, T> {
+impl<K, T> Snapshot<K, T> {
     pub const fn new(
         checkpoints: &'static str,
         changelog: &'static str,
@@ -37,6 +38,18 @@ impl<'a, K, T> Snapshot<K, T> {
         Snapshot {
             checkpoints: Map::new(checkpoints),
             changelog: Map::new(changelog),
+            strategy,
+        }
+    }
+
+    pub fn new_generic(
+        checkpoints: impl Into<Ns>,
+        changelog: impl Into<Ns>,
+        strategy: Strategy,
+    ) -> Snapshot<K, T> {
+        Snapshot {
+            checkpoints: Map::new_generic(checkpoints),
+            changelog: Map::new_generic(changelog),
             strategy,
         }
     }

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -7,7 +7,7 @@ pub use map::SnapshotMap;
 
 use crate::bound::Bound;
 use crate::de::KeyDeserialize;
-use crate::namespace::Ns;
+use crate::namespace::Namespace;
 use crate::{Map, Prefixer, PrimaryKey};
 use cosmwasm_std::{Order, StdError, StdResult, Storage};
 use serde::de::DeserializeOwned;
@@ -49,8 +49,8 @@ impl<K, T> Snapshot<K, T> {
     /// Use this if you might need to handle dynamic strings. Otherwise, you might
     /// prefer [`Snapshot::new`].
     pub fn new_generic(
-        checkpoints: impl Into<Ns>,
-        changelog: impl Into<Ns>,
+        checkpoints: impl Into<Namespace>,
+        changelog: impl Into<Namespace>,
         strategy: Strategy,
     ) -> Snapshot<K, T> {
         Snapshot {

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -30,6 +30,9 @@ pub(crate) struct Snapshot<K, T> {
 }
 
 impl<K, T> Snapshot<K, T> {
+    /// Creates a new [`Snapshot`] with the given storage keys and strategy.
+    /// This is a const fn only suitable when all the storage keys provided are
+    /// static strings.
     pub const fn new(
         checkpoints: &'static str,
         changelog: &'static str,
@@ -42,6 +45,9 @@ impl<K, T> Snapshot<K, T> {
         }
     }
 
+    /// Creates a new [`Snapshot`] with the given storage keys and strategy.
+    /// Use this if you might need to handle dynamic strings. Otherwise, you might
+    /// prefer [`Snapshot::new`].
     pub fn new_generic(
         checkpoints: impl Into<Ns>,
         changelog: impl Into<Ns>,


### PR DESCRIPTION
Breaking. Don't merge until 2.0.0!

## Description

This PR
- removes lifetime parameters from collection types when they relate to the lifetime of the "namespace" string slice; the reasoning is that said string slices are always `'static` anyway,
- introduces `new_dyn`: a non-const constructor to most collection types that allows passing an owned `String` as the namespace; the idea is to allow storage keys calculated at runtime.

## Decisions

I went with the `const fn new` vs `fn new_dyn` constructors to allow for flexibility while still having an API that allows constant initialization with static strings. Admittedly, I didn't think about it for horribly long - if you think you have a better design in mind, you probably do. LMK!

~~Should `new_generic` be renamed to `new_dynamic`?~~