### PR TITLE
Make `Snapshot` take a strategy trait so that users can write their own strategies

### DIFF
--- a/src/indexed_snapshot.rs
+++ b/src/indexed_snapshot.rs
@@ -14,15 +14,15 @@ use crate::PrefixBound;
 use crate::{Bound, IndexList, Map, Path, Strategy};
 
 /// `IndexedSnapshotMap` works like a `SnapshotMap` but has a secondary index
-pub struct IndexedSnapshotMap<'a, K, T, I> {
+pub struct IndexedSnapshotMap<'a, K, T, I, S = Strategy> {
     pk_namespace: &'a [u8],
-    primary: SnapshotMap<'a, K, T>,
+    primary: SnapshotMap<'a, K, T, S>,
     /// This is meant to be read directly to get the proper types, like:
     /// map.idx.owner.items(...)
     pub idx: I,
 }
 
-impl<'a, K, T, I> IndexedSnapshotMap<'a, K, T, I> {
+impl<'a, K, T, I, S> IndexedSnapshotMap<'a, K, T, I, S> {
     /// Examples:
     ///
     /// ```rust
@@ -48,7 +48,7 @@ impl<'a, K, T, I> IndexedSnapshotMap<'a, K, T, I> {
         pk_namespace: &'a str,
         checkpoints: &'a str,
         changelog: &'a str,
-        strategy: Strategy,
+        strategy: S,
         indexes: I,
     ) -> Self {
         IndexedSnapshotMap {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub use path::Path;
 #[cfg(feature = "iterator")]
 pub use prefix::{range_with_prefix, Prefix};
 #[cfg(feature = "iterator")]
-pub use snapshot::{SnapshotItem, SnapshotMap, Strategy};
+pub use snapshot::{IntervalStrategy, SnapshotItem, SnapshotMap, Strategy};
 
 // cw_storage_macro reexports
 #[cfg(all(feature = "iterator", feature = "macro"))]

--- a/src/snapshot/interval_strategy.rs
+++ b/src/snapshot/interval_strategy.rs
@@ -1,0 +1,103 @@
+use cosmwasm_std::{StdResult, Storage};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+use crate::{KeyDeserialize, Prefixer, PrimaryKey};
+
+use super::{Snapshot, SnapshotStrategy};
+
+/// A SnapshotStrategy that takes a snapshot only if at least the specified interval has passed.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct IntervalStrategy {
+    /// The interval to archive snapshots at. If the time or number of blocks since the last changelog
+    /// entry is greater than this interval, a new snapshot will be created.
+    pub interval: u64,
+}
+
+impl IntervalStrategy {
+    /// Create a new IntervalStrategy with the given interval.
+    pub const fn new(interval: u64) -> Self {
+        Self { interval }
+    }
+}
+
+impl<'a, K, T> SnapshotStrategy<'a, K, T> for IntervalStrategy
+where
+    T: Serialize + DeserializeOwned + Clone,
+    K: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize,
+{
+    fn assert_checkpointed(
+        &self,
+        _store: &dyn Storage,
+        _snapshot: &Snapshot<K, T, Self>,
+        _height: u64,
+    ) -> StdResult<()> {
+        Ok(())
+    }
+
+    fn should_archive(
+        &self,
+        store: &dyn Storage,
+        snapshot: &Snapshot<'a, K, T, Self>,
+        key: &K,
+        height: u64,
+    ) -> StdResult<bool> {
+        let last_height = height.saturating_sub(self.interval);
+        let change_since_interval = snapshot.may_load_at_height(store, key.clone(), last_height)?;
+
+        Ok(change_since_interval.is_none())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cosmwasm_std::testing::MockStorage;
+
+    type TestSnapshot = Snapshot<'static, &'static str, u64, IntervalStrategy>;
+    const INTERVAL_5: TestSnapshot = Snapshot::new(
+        "interval_5__check",
+        "interval_5__change",
+        IntervalStrategy::new(5),
+    );
+
+    const DUMMY_KEY: &str = "dummy";
+
+    #[test]
+    fn should_archive() {
+        let mut store = MockStorage::new();
+
+        // Should archive first save since there is no previous changelog entry.
+        assert_eq!(INTERVAL_5.should_archive(&store, &DUMMY_KEY, 0), Ok(true));
+
+        // Store changelog entry
+        INTERVAL_5
+            .write_changelog(&mut store, DUMMY_KEY, 0, None)
+            .unwrap();
+
+        // Should not archive again
+        assert_eq!(INTERVAL_5.should_archive(&store, &DUMMY_KEY, 0), Ok(false));
+
+        // Should archive once interval has passed
+        assert_eq!(INTERVAL_5.should_archive(&store, &DUMMY_KEY, 6), Ok(true));
+
+        // Store changelog entry
+        INTERVAL_5
+            .write_changelog(&mut store, DUMMY_KEY, 6, None)
+            .unwrap();
+
+        // Should not archive again
+        assert_eq!(INTERVAL_5.should_archive(&store, &DUMMY_KEY, 6), Ok(false));
+
+        // Should not archive before interval
+        assert_eq!(
+            INTERVAL_5.should_archive(&store, &DUMMY_KEY, 6 + 5),
+            Ok(false)
+        );
+
+        // Should archive once interval has passed
+        assert_eq!(
+            INTERVAL_5.should_archive(&store, &DUMMY_KEY, 6 + 5 + 1),
+            Ok(true)
+        );
+    }
+}

--- a/src/snapshot/item.rs
+++ b/src/snapshot/item.rs
@@ -73,14 +73,14 @@ where
     }
 
     pub fn save(&self, store: &mut dyn Storage, data: &T, height: u64) -> StdResult<()> {
-        if self.snapshots.should_archive(store, &())? {
+        if self.snapshots.should_archive(store, &(), height)? {
             self.write_change(store, height)?;
         }
         self.primary.save(store, data)
     }
 
     pub fn remove(&self, store: &mut dyn Storage, height: u64) -> StdResult<()> {
-        if self.snapshots.should_archive(store, &())? {
+        if self.snapshots.should_archive(store, &(), height)? {
             self.write_change(store, height)?;
         }
         self.primary.remove(store);

--- a/src/snapshot/map.rs
+++ b/src/snapshot/map.rs
@@ -88,14 +88,14 @@ where
     }
 
     pub fn save(&self, store: &mut dyn Storage, k: K, data: &T, height: u64) -> StdResult<()> {
-        if self.snapshots.should_archive(store, &k)? {
+        if self.snapshots.should_archive(store, &k, height)? {
             self.write_change(store, k.clone(), height)?;
         }
         self.primary.save(store, k, data)
     }
 
     pub fn remove(&self, store: &mut dyn Storage, k: K, height: u64) -> StdResult<()> {
-        if self.snapshots.should_archive(store, &k)? {
+        if self.snapshots.should_archive(store, &k, height)? {
             self.write_change(store, k.clone(), height)?;
         }
         self.primary.remove(store, k);

--- a/src/snapshot/map.rs
+++ b/src/snapshot/map.rs
@@ -13,15 +13,17 @@ use crate::prefix::{namespaced_prefix_range, Prefix};
 use crate::snapshot::{ChangeSet, Snapshot};
 use crate::{Bound, Prefixer, Strategy};
 
+use super::SnapshotStrategy;
+
 /// Map that maintains a snapshots of one or more checkpoints.
 /// We can query historical data as well as current state.
 /// What data is snapshotted depends on the Strategy.
-pub struct SnapshotMap<'a, K, T> {
+pub struct SnapshotMap<'a, K, T, S = Strategy> {
     primary: Map<'a, K, T>,
-    snapshots: Snapshot<'a, K, T>,
+    snapshots: Snapshot<'a, K, T, S>,
 }
 
-impl<'a, K, T> SnapshotMap<'a, K, T> {
+impl<'a, K, T, S> SnapshotMap<'a, K, T, S> {
     /// Example:
     ///
     /// ```rust
@@ -34,12 +36,7 @@ impl<'a, K, T> SnapshotMap<'a, K, T> {
     ///     Strategy::EveryBlock
     /// );
     /// ```
-    pub const fn new(
-        pk: &'a str,
-        checkpoints: &'a str,
-        changelog: &'a str,
-        strategy: Strategy,
-    ) -> Self {
+    pub const fn new(pk: &'a str, checkpoints: &'a str, changelog: &'a str, strategy: S) -> Self {
         SnapshotMap {
             primary: Map::new(pk),
             snapshots: Snapshot::new(checkpoints, changelog, strategy),
@@ -51,7 +48,7 @@ impl<'a, K, T> SnapshotMap<'a, K, T> {
     }
 }
 
-impl<'a, K, T> SnapshotMap<'a, K, T>
+impl<'a, K, T, S> SnapshotMap<'a, K, T, S>
 where
     T: Serialize + DeserializeOwned + Clone,
     K: PrimaryKey<'a> + Prefixer<'a>,
@@ -65,10 +62,11 @@ where
     }
 }
 
-impl<'a, K, T> SnapshotMap<'a, K, T>
+impl<'a, K, T, S> SnapshotMap<'a, K, T, S>
 where
     T: Serialize + DeserializeOwned + Clone,
     K: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize,
+    S: SnapshotStrategy<'a, K, T>,
 {
     pub fn key(&self, k: K) -> Path<T> {
         self.primary.key(k)
@@ -90,14 +88,14 @@ where
     }
 
     pub fn save(&self, store: &mut dyn Storage, k: K, data: &T, height: u64) -> StdResult<()> {
-        if self.snapshots.should_checkpoint(store, &k)? {
+        if self.snapshots.should_archive(store, &k)? {
             self.write_change(store, k.clone(), height)?;
         }
         self.primary.save(store, k, data)
     }
 
     pub fn remove(&self, store: &mut dyn Storage, k: K, height: u64) -> StdResult<()> {
-        if self.snapshots.should_checkpoint(store, &k)? {
+        if self.snapshots.should_archive(store, &k)? {
             self.write_change(store, k.clone(), height)?;
         }
         self.primary.remove(store, k);
@@ -162,10 +160,11 @@ where
 }
 
 // short-cut for simple keys, rather than .prefix(()).range_raw(...)
-impl<'a, K, T> SnapshotMap<'a, K, T>
+impl<'a, K, T, S> SnapshotMap<'a, K, T, S>
 where
     T: Serialize + DeserializeOwned + Clone,
     K: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize,
+    S: SnapshotStrategy<'a, K, T>,
 {
     // I would prefer not to copy code from Prefix, but no other way
     // with lifetimes (create Prefix inside function and return ref = no no)
@@ -197,7 +196,7 @@ where
 }
 
 #[cfg(feature = "iterator")]
-impl<'a, K, T> SnapshotMap<'a, K, T>
+impl<'a, K, T, S> SnapshotMap<'a, K, T, S>
 where
     T: Serialize + DeserializeOwned,
     K: PrimaryKey<'a> + KeyDeserialize,

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -1,7 +1,9 @@
 #![cfg(feature = "iterator")]
+mod interval_strategy;
 mod item;
 mod map;
 
+pub use interval_strategy::IntervalStrategy;
 pub use item::SnapshotItem;
 pub use map::SnapshotMap;
 

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -67,8 +67,8 @@ where
     K: PrimaryKey<'a> + Prefixer<'a> + KeyDeserialize,
     S: SnapshotStrategy<'a, K, T>,
 {
-    pub fn should_archive(&self, store: &dyn Storage, key: &K) -> StdResult<bool> {
-        self.strategy.should_archive(store, self, key)
+    pub fn should_archive(&self, store: &dyn Storage, key: &K, height: u64) -> StdResult<bool> {
+        self.strategy.should_archive(store, self, key, height)
     }
 
     pub fn assert_checkpointed(&self, store: &dyn Storage, height: u64) -> StdResult<()> {
@@ -108,7 +108,7 @@ where
         key: K,
         height: u64,
     ) -> StdResult<Option<Option<T>>> {
-        self.strategy.assert_checkpointed(store, self, height)?;
+        self.assert_checkpointed(store, height)?;
 
         // this will look for the first snapshot of height >= given height
         // If None, there is no snapshot since that time.
@@ -147,6 +147,7 @@ where
         store: &dyn Storage,
         snapshot: &Snapshot<'a, K, T, Self>,
         key: &K,
+        height: u64,
     ) -> StdResult<bool>;
 }
 
@@ -191,6 +192,7 @@ where
         store: &dyn Storage,
         snapshot: &Snapshot<'a, K, T, Self>,
         k: &K,
+        _height: u64,
     ) -> StdResult<bool> {
         match self {
             Strategy::EveryBlock => Ok(true),
@@ -247,9 +249,9 @@ mod tests {
     fn should_checkpoint() {
         let storage = MockStorage::new();
 
-        assert_eq!(NEVER.should_archive(&storage, &DUMMY_KEY), Ok(false));
-        assert_eq!(EVERY.should_archive(&storage, &DUMMY_KEY), Ok(true));
-        assert_eq!(SELECT.should_archive(&storage, &DUMMY_KEY), Ok(false));
+        assert_eq!(NEVER.should_archive(&storage, &DUMMY_KEY, 0), Ok(false));
+        assert_eq!(EVERY.should_archive(&storage, &DUMMY_KEY, 0), Ok(true));
+        assert_eq!(SELECT.should_archive(&storage, &DUMMY_KEY, 0), Ok(false));
     }
 
     #[test]


### PR DESCRIPTION
This PR adds a `SnapshotStrategy` trait and adds a generic to `Snapshot`, `SnapshotMap`, `SnapshotItem`, and `IndexedSnapshotMap`. It also implements the `SnapshotStrategy` trait for the `Strategy` enum.

This PR also adds a `IntervalStrategy` struct which is a strategy that only stores data to the changelog if at least a certain number of blocks has passed.

I tried my best to make these changes non-breaking and I think I succeeded. However, I think there are more changes that could be make to simplify and improve `Snapshot`. For example, I found the "checkpointing" and the fn `assert_checkpointed` quite confusing and it seems this is only used in the `Strategy::Selected` variant. I couldn't figure out a way to move this logic into this variant without making breaking changes.

I also found it a bit unintuitive that in `SnapshotMap`, data added to the changelog use the current height and not the height at which they were originally saved to the `primary` `Map`. For the current purposes that I want to use SnapshotMap for it would make sense to use the height at which the data was originally saved, so that the changelog becomes a record of history rather than having a delay in the heights. Would you be interested in me adding an alternative implementation that accomplishes this? Trying to modify the current implementation would cause breaking changes. 