### PR TITLE
Make `Uint64`, `Uint128`, `Int64`, `Int128` usable as keys

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1,7 +1,7 @@
 use std::array::TryFromSliceError;
 use std::convert::TryInto;
 
-use cosmwasm_std::{Addr, StdError, StdResult};
+use cosmwasm_std::{Addr, Int128, Int64, StdError, StdResult, Uint128, Uint64};
 
 use crate::int_key::IntKey;
 
@@ -156,7 +156,7 @@ macro_rules! integer_de {
     }
 }
 
-integer_de!(for i8, u8, i16, u16, i32, u32, i64, u64, i128, u128);
+integer_de!(for i8, u8, i16, u16, i32, u32, i64, u64, i128, u128, Uint64, Uint128, Int64, Int128);
 
 fn parse_length(value: &[u8]) -> StdResult<usize> {
     Ok(u16::from_be_bytes(

--- a/src/int_key.rs
+++ b/src/int_key.rs
@@ -1,5 +1,7 @@
 use std::mem;
 
+use cosmwasm_std::{Int128, Int64, Uint128, Uint64};
+
 /// Our int keys are simply the big-endian representation bytes for unsigned ints,
 /// but "sign-flipped" (xored msb) big-endian bytes for signed ints.
 ///
@@ -50,6 +52,28 @@ macro_rules! cw_int_keys {
 }
 
 cw_int_keys!(for i8, u8, i16, u16, i32, u32, i64, u64, i128, u128);
+
+macro_rules! cw_uint_std_keys {
+    (for $($t:ty => $tt:ident),+) => {
+        $(impl IntKey for $t {
+            type Buf = [u8; mem::size_of::<$t>()];
+
+            #[inline]
+            fn to_cw_bytes(&self) -> Self::Buf {
+                self.$tt().to_cw_bytes()
+            }
+
+            #[inline]
+            fn from_cw_bytes(bytes: Self::Buf) -> Self {
+                Self::new(IntKey::from_cw_bytes(bytes))
+            }
+        })*
+    }
+}
+
+// the bit after => is the name of the method to convert to the underlying type
+// e.g. Uint64 => u64 means Uint64 has a method .u64() that returns a u64
+cw_uint_std_keys!(for Uint64 => u64, Uint128 => u128,Int64 => i64, Int128 => i128);
 
 #[cfg(test)]
 mod test {

--- a/src/int_key.rs
+++ b/src/int_key.rs
@@ -54,13 +54,13 @@ macro_rules! cw_int_keys {
 cw_int_keys!(for i8, u8, i16, u16, i32, u32, i64, u64, i128, u128);
 
 macro_rules! cw_uint_std_keys {
-    (for $($t:ty => $tt:ident),+) => {
+    (for $($t:ty),+) => {
         $(impl IntKey for $t {
             type Buf = [u8; mem::size_of::<$t>()];
 
             #[inline]
             fn to_cw_bytes(&self) -> Self::Buf {
-                self.$tt().to_cw_bytes()
+                self.to_be_bytes()
             }
 
             #[inline]
@@ -71,9 +71,29 @@ macro_rules! cw_uint_std_keys {
     }
 }
 
-// the bit after => is the name of the method to convert to the underlying type
-// e.g. Uint64 => u64 means Uint64 has a method .u64() that returns a u64
-cw_uint_std_keys!(for Uint64 => u64, Uint128 => u128,Int64 => i64, Int128 => i128);
+cw_uint_std_keys!(for Uint64, Uint128);
+
+macro_rules! cw_int_std_keys {
+    (for $($t:ty),+) => {
+        $(impl IntKey for $t {
+            type Buf = [u8; mem::size_of::<$t>()];
+
+            #[inline]
+            fn to_cw_bytes(&self) -> Self::Buf {
+                let mut bytes = self.to_be_bytes();
+                bytes[0] ^= 0x80;
+                bytes
+            }
+
+            #[inline]
+            fn from_cw_bytes(bytes: Self::Buf) -> Self {
+                Self::new(IntKey::from_cw_bytes(bytes))
+            }
+        })*
+    }
+}
+
+cw_int_std_keys!(for Int64, Int128);
 
 #[cfg(test)]
 mod test {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::{storage_keys::namespace_with_key, Addr};
+use cosmwasm_std::{Int128, Int64, Uint128, Uint64};
 
 use crate::de::KeyDeserialize;
 use crate::int_key::IntKey;
@@ -304,8 +305,7 @@ macro_rules! integer_key {
     }
 }
 
-integer_key!(for i8, Val8, u8, Val8, i16, Val16, u16, Val16, i32, Val32, u32, Val32, i64, Val64, u64, Val64, i128, Val128, u128, Val128);
-
+integer_key!(for i8, Val8, u8, Val8, i16, Val16, u16, Val16, i32, Val32, u32, Val32, i64, Val64, u64, Val64, i128, Val128, u128, Val128, Uint64, Val64, Uint128, Val128, Int64, Val64, Int128, Val128);
 macro_rules! integer_prefix {
     (for $($t:ty, $v:tt),+) => {
         $(impl<'a> Prefixer<'a> for $t {
@@ -316,7 +316,7 @@ macro_rules! integer_prefix {
     }
 }
 
-integer_prefix!(for i8, Val8, u8, Val8, i16, Val16, u16, Val16, i32, Val32, u32, Val32, i64, Val64, u64, Val64, i128, Val128, u128, Val128);
+integer_prefix!(for i8, Val8, u8, Val8, i16, Val16, u16, Val16, i32, Val32, u32, Val32, i64, Val64, u64, Val64, i128, Val128, u128, Val128, Uint64, Val64, Uint128, Val128, Int64, Val64, Int128, Val128);
 
 #[cfg(test)]
 mod test {
@@ -387,6 +387,38 @@ mod test {
         let path = k.key();
         assert_eq!(1, path.len());
         assert_eq!(4242i128.to_cw_bytes(), path[0].as_ref());
+    }
+
+    #[test]
+    fn std_uint64_key_works() {
+        let k: Uint64 = Uint64::from(4242u64);
+        let path = k.key();
+        assert_eq!(1, path.len());
+        assert_eq!(4242u64.to_cw_bytes(), path[0].as_ref());
+    }
+
+    #[test]
+    fn std_uint128_key_works() {
+        let k: Uint128 = Uint128::from(4242u128);
+        let path = k.key();
+        assert_eq!(1, path.len());
+        assert_eq!(4242u128.to_cw_bytes(), path[0].as_ref());
+    }
+
+    #[test]
+    fn std_int64_key_works() {
+        let k: Int64 = Int64::from(-4242i64);
+        let path = k.key();
+        assert_eq!(1, path.len());
+        assert_eq!((-4242i64).to_cw_bytes(), path[0].as_ref());
+    }
+
+    #[test]
+    fn std_int128_key_works() {
+        let k: Int128 = Int128::from(-4242i128);
+        let path = k.key();
+        assert_eq!(1, path.len());
+        assert_eq!((-4242i128).to_cw_bytes(), path[0].as_ref());
     }
 
     #[test]


### PR DESCRIPTION
This doesn't break the API in a very serious way.

I think if we want to do the same for 256-bit and 512-bit values, we'll need to break API by [adding larger variants to this enum](https://docs.rs/cw-storage-plus/latest/cw_storage_plus/enum.Key.html). I guess we might as well (in another PR) since we're likely to release cw-storage-plus 3.0.0.