### PR TITLE
Bump maximal build to Rust 1.75

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
 
   build_maximal:
     docker:
-      - image: rust:1.65.0
+      - image: rust:1.75.0
     working_directory: ~/project/
     steps:
       - checkout
@@ -117,7 +117,7 @@ jobs:
           command: cargo update
       - restore_cache:
           keys:
-            - cargocache-v2-storage-plus:1.65.0-{{ checksum "Cargo.lock" }}
+            - cargocache-v2-storage-plus:1.75.0-{{ checksum "Cargo.lock" }}
       - run:
           name: Build library for native target (with iterator and macro)
           command: cargo build --locked --all-features
@@ -128,7 +128,7 @@ jobs:
           paths:
             - /usr/local/cargo/registry
             - target
-          key: cargocache-v2-storage-plus:1.65.0-{{ checksum "Cargo.lock" }}
+          key: cargocache-v2-storage-plus:1.75.0-{{ checksum "Cargo.lock" }}
 
   lint:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ jobs:
   coverage:
     # https://circleci.com/developer/images?imageType=machine
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2204:2024.01.1
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This should fix [the failing `build_maximal` job](https://app.circleci.com/jobs/github/CosmWasm/cw-storage-plus/2102).