### PR TITLE
Make a mismatch of PK in an IndexedMap impossible (alt)

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -7,9 +7,9 @@ For more information on this package, please check out the
 
 use proc_macro::TokenStream;
 use syn::{
-    Ident,
+    Ident, Type, TypePath,
     __private::{quote::quote, Span},
-    parse_macro_input, ItemStruct,
+    parse_macro_input, ItemStruct, Lifetime,
 };
 
 #[proc_macro_attribute]
@@ -29,12 +29,28 @@ pub fn index_list(attr: TokenStream, item: TokenStream) -> TokenStream {
         })
         .collect::<Vec<_>>();
 
+    let mut first_ix_type = input.fields.iter().next().unwrap().ty.clone();
+    // change all lifetime params to 'static
+    if let Type::Path(TypePath { ref mut path, .. }) = first_ix_type {
+        path.segments.iter_mut().for_each(|seg| {
+            if let syn::PathArguments::AngleBracketed(ref mut args) = seg.arguments {
+                for arg in args.args.iter_mut() {
+                    if let syn::GenericArgument::Lifetime(ref mut lt) = arg {
+                        *lt = Lifetime::new("'static", Span::call_site());
+                    }
+                }
+            }
+        });
+    }
+
     let expanded = quote! {
         #input
 
         impl cw_storage_plus::IndexList<#ty> for #struct_ty<'_> {
-            fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn cw_storage_plus::Index<#ty>> + '_> {
-                let v: Vec<&dyn cw_storage_plus::Index<#ty>> = vec![#(#names),*];
+            type PK = <#first_ix_type as ::cw_storage_plus::Index<#ty>>::PK;
+
+            fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn cw_storage_plus::Index<#ty, PK = Self::PK>> + '_> {
+                let v: Vec<&dyn cw_storage_plus::Index<#ty, PK = Self::PK>> = vec![#(#names),*];
                 Box::new(v.into_iter())
             }
         }

--- a/src/indexed_snapshot.rs
+++ b/src/indexed_snapshot.rs
@@ -326,8 +326,13 @@ mod test {
 
     // Future Note: this can likely be macro-derived
     impl<'a> IndexList<Data> for DataIndexes<'a> {
-        fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<Data>> + '_> {
-            let v: Vec<&dyn Index<Data>> = vec![&self.name, &self.age, &self.name_lastname];
+        type PK = String;
+
+        fn get_indexes(
+            &'_ self,
+        ) -> Box<dyn Iterator<Item = &'_ dyn Index<Data, PK = Self::PK>> + '_> {
+            let v: Vec<&dyn Index<Data, PK = Self::PK>> =
+                vec![&self.name, &self.age, &self.name_lastname];
             Box::new(v.into_iter())
         }
     }
@@ -340,8 +345,12 @@ mod test {
 
     // Future Note: this can likely be macro-derived
     impl<'a> IndexList<Data> for DataCompositeMultiIndex<'a> {
-        fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<Data>> + '_> {
-            let v: Vec<&dyn Index<Data>> = vec![&self.name_age];
+        type PK = String;
+
+        fn get_indexes(
+            &'_ self,
+        ) -> Box<dyn Iterator<Item = &'_ dyn Index<Data, PK = Self::PK>> + '_> {
+            let v: Vec<&dyn Index<Data, PK = Self::PK>> = vec![&self.name_age];
             Box::new(v.into_iter())
         }
     }

--- a/src/indexes/mod.rs
+++ b/src/indexes/mod.rs
@@ -19,6 +19,8 @@ pub trait Index<T>
 where
     T: Serialize + DeserializeOwned + Clone,
 {
+    type PK;
+
     fn save(&self, store: &mut dyn Storage, pk: &[u8], data: &T) -> StdResult<()>;
     fn remove(&self, store: &mut dyn Storage, pk: &[u8], old_data: &T) -> StdResult<()>;
 }

--- a/src/indexes/multi.rs
+++ b/src/indexes/multi.rs
@@ -134,6 +134,8 @@ where
     T: Serialize + DeserializeOwned + Clone,
     IK: PrimaryKey<'a>,
 {
+    type PK = PK;
+
     fn save(&self, store: &mut dyn Storage, pk: &[u8], data: &T) -> StdResult<()> {
         let idx = (self.index)(pk, data).joined_extra_key(pk);
         self.idx_map.save(store, idx, &(pk.len() as u32))

--- a/src/indexes/unique.rs
+++ b/src/indexes/unique.rs
@@ -67,6 +67,8 @@ where
     T: Serialize + DeserializeOwned + Clone,
     IK: PrimaryKey<'a>,
 {
+    type PK = PK;
+
     fn save(&self, store: &mut dyn Storage, pk: &[u8], data: &T) -> StdResult<()> {
         let idx = (self.index)(data);
         // error if this is already set

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ extern crate cw_storage_macro;
 /// #[index_list(TestStruct)] // <- Add this line right here.
 /// struct TestIndexes<'a> {
 ///     id: MultiIndex<'a, u32, TestStruct, u64>,
-///     addr: UniqueIndex<'a, Addr, TestStruct, ()>,
+///     addr: UniqueIndex<'a, Addr, TestStruct, u64>,
 /// }
 /// ```
 ///

--- a/tests/index_list.rs
+++ b/tests/index_list.rs
@@ -17,7 +17,7 @@ mod test {
         #[index_list(TestStruct)]
         struct TestIndexes<'a> {
             id: MultiIndex<'a, u32, TestStruct, u64>,
-            addr: UniqueIndex<'a, Addr, TestStruct, ()>,
+            addr: UniqueIndex<'a, Addr, TestStruct, u64>,
         }
 
         let _: IndexedMap<u64, TestStruct, TestIndexes> = IndexedMap::new(
@@ -41,7 +41,7 @@ mod test {
         #[index_list(TestStruct)]
         struct TestIndexes<'a> {
             id: MultiIndex<'a, u32, TestStruct, u64>,
-            addr: UniqueIndex<'a, Addr, TestStruct, ()>,
+            addr: UniqueIndex<'a, Addr, TestStruct, u64>,
         }
 
         let mut storage = MockStorage::new();


### PR DESCRIPTION
Closes #83 

This PR uses assoc types instead of generic params. Seems this allows some trickery with the macro.