### PR TITLE
Fix typo in the file CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,7 +310,7 @@ changelog will be noisy - not everything is relevant to `cw-storage-plus` there.
 - Update changelog add upcoming [\#675](https://github.com/CosmWasm/cw-plus/pull/675) ([maurolacy](https://github.com/maurolacy))
 - Reject proposals early [\#668](https://github.com/CosmWasm/cw-plus/pull/668) ([Callum-A](https://github.com/Callum-A))
 - cw20-base: validate addresses are unique in initial balances [\#659](https://github.com/CosmWasm/cw-plus/pull/659) ([harryscholes](https://github.com/harryscholes))
-- New SECURITY.md refering to wasmd [\#624](https://github.com/CosmWasm/cw-plus/pull/624) ([ethanfrey](https://github.com/ethanfrey))
+- New SECURITY.md referring to wasmd [\#624](https://github.com/CosmWasm/cw-plus/pull/624) ([ethanfrey](https://github.com/ethanfrey))
 
 ## [v0.13.0](https://github.com/CosmWasm/cw-plus/tree/v0.13.0) (2022-03-09)
 


### PR DESCRIPTION
# Pull Request: Fix Typo in `CHANGELOG.md`

## Description

This pull request fixes a typo in the `CHANGELOG.md` file. The word **"refering"** was corrected to **"referring"**.

### Changes Made
- Corrected a typo:
  - Original: `refering`
  - Updated: `referring`

### Why This Change is Necessary
- Improves the accuracy and professionalism of the documentation.
- Enhances readability and ensures correct spelling.

## Checklist
- [x] The change is limited to fixing a typo.
- [x] No functional code or behavior was modified.
- [x] Documentation is now consistent and clear.

## Related Issues
N/A

## Additional Notes
- This is a non-functional change and does not impact the behavior or logic of the project.

Thank you for reviewing this pull request! 🌟
