### PR TITLE
Updated `cosmwasm-std` dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,37 +76,6 @@ jobs:
             - target
           key: cargocache-v2-storage-plus:1.81-{{ checksum "Cargo.lock" }}
 
-  build_minimal:
-    docker:
-      - image: rustlang/rust:nightly
-    working_directory: ~/project/
-    steps:
-      - checkout
-      - run:
-          name: Version information
-          command: rustc --version; cargo --version; rustup --version; rustup target list --installed
-      - run:
-          name: Remove Cargo.lock
-          command: rm Cargo.lock
-      # 👇 Remove this command after dependencies in crate num-bigint are upgraded!
-      - run:
-          name: Temporarily update problematic crate
-          command: cargo update -p num-bigint
-      - restore_cache:
-          keys:
-            - cargocache-v2-storage-plus:1.81-minimal-{{ checksum "~/project/Cargo.toml" }}
-      - run:
-          name: Build library for native target (with iterator and macro)
-          command: cargo build -Zminimal-versions --all-features
-      - run:
-          name: Run unit tests (with iterator and macro)
-          command: cargo test --workspace -Zminimal-versions --all-features
-      - save_cache:
-          paths:
-            - /usr/local/cargo/registry
-            - target
-          key: cargocache-v2-storage-plus:1.81-minimal-{{ checksum "~/project/Cargo.toml" }}
-
   build_maximal:
     docker:
       - image: rust:1.81

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,6 @@ workflows:
               only:
                 - main
     jobs:
-      # Build with minimal versions of dependencies
-      - build_minimal
       # Build with maximal versions of dependencies
       - build_maximal
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ workflows:
   test:
     jobs:
       - build_and_test
-      - build_minimal
       - build_maximal
       - lint
       - benchmarking:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [3.0.0-rc.0] - 2025-06-04
+
+### Changed
+
+- Upgraded to `cosmwasm-std` 3.0.0-rc.0 ([#100])
+
+[#100]: https://github.com/CosmWasm/cw-storage-plus/pull/100
+
 ## [3.0.0-ibc2.0] - 2025-05-26
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,15 +272,15 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-core"
-version = "3.0.0-ibc2.0"
+version = "3.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc3b99cecbb7241d23c836b5c133a977a653132d95db59460b5f77e6df4a4aba"
+checksum = "10492ce426180bb1a84d056cef0a38c82bce63b4ee333ac689807d418d74d5a9"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "3.0.0-ibc2.0"
+version = "3.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad7bb38ec04c06f8f674cb9aeaefc7bae0d2b7d3010bf82a0a6a7f29e3a53e00"
+checksum = "383f3314a0b39f3e926bbbfb3c3fc5d86bb832adc445c29525c9d7ce249e946f"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -292,6 +292,7 @@ dependencies = [
  "ecdsa",
  "ed25519-zebra",
  "k256",
+ "num-bigint",
  "num-traits",
  "p256",
  "rand_core",
@@ -302,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "3.0.0-ibc2.0"
+version = "3.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5bcb464269394b48737ea66e81f16ceecbf0d0859f06c9868f3e368d140273"
+checksum = "dac4e791098c89ad6e2b3828f77334906f12f7ea58846406a2562c6daf984c1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -313,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "3.0.0-ibc2.0"
+version = "3.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e74bac779abdc4e2ed0e8005351f8b7763a12620b0667ae2d381a37c3f031b1"
+checksum = "c2a509852d24b93d7a808d638c9509e7bd3119895adaddf764f0090d10a7ad6c"
 dependencies = [
  "base64",
  "bech32",
@@ -323,7 +324,7 @@ dependencies = [
  "cosmwasm-core",
  "cosmwasm-crypto",
  "cosmwasm-derive",
- "derive_more",
+ "derive_more 2.0.1",
  "hex",
  "rand_core",
  "rmp-serde",
@@ -486,17 +487,16 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "3.0.0-ibc2.0"
+version = "3.0.0-rc.0"
 dependencies = [
  "cosmwasm-std",
  "criterion",
  "cw-storage-macro",
- "derive_more",
+ "derive_more 1.0.0-beta.6",
  "rand",
  "rand_xoshiro",
  "schemars",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -515,7 +515,16 @@ version = "1.0.0-beta.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7abbfc297053be59290e3152f8cbcd52c8642e0728b69ee187d991d4c1af08d"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 1.0.0-beta.6",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl 2.0.1",
 ]
 
 [[package]]
@@ -525,6 +534,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bba3e9872d7c58ce7ef0fcf1844fcc3e23ef2a58377b50df35dd98e42a5726e"
 dependencies = [
  "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn",
@@ -1068,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "cw-storage-plus"
-version = "3.0.0-ibc2.0"
+version = "3.0.0-rc.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2021"
 description = "Enhanced storage engines"
@@ -23,8 +23,8 @@ macro = ["cw-storage-macro"]
 bench = false
 
 [dependencies]
-cosmwasm-std = { version = "3.0.0-ibc2.0", default-features = false, features = ["std"] }
-schemars = "0.8.3"
+cosmwasm-std = { version = "3.0.0-rc.0", default-features = false, features = ["std"] }
+schemars = "0.8.22"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 cw-storage-macro = { version = "2.0.0", optional = true, path = "macros" }
 
@@ -35,11 +35,6 @@ criterion = { version = "0.3", features = ["html_reports"] }
 rand = { version = "0.8", default-features = false }
 rand_xoshiro = { version = "0.6.0", default-features = false }
 derive_more = { version = "=1.0.0-beta.6", features = ["full"] }
-
-# We don't use the following dependencies directly. They're dependencies of our dependencies.
-# We specify them to tighten their version requirements so that builds with `-Zminimal-versions` work.
-# https://github.com/GREsau/schemars/pull/192 is merged, we can update schemars and release this.
-serde_json = "1.0.29"
 
 [[bench]]
 name = "main"


### PR DESCRIPTION
- Updated `cosmwas-std` dependency to version **3.0.0-rc.0**.
- Removed minimal build from CI checks.
- Removed dependencies needed only for making `-Zminimal-versions` work.

> NOTE: Consider running `cargo update` on your project if you encounter any problems compiling `cw-storag-plus`.