### PR TITLE
Bumped version of cw-storage-macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-macro"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "3.0.0-rc.1"
+version = "3.0.0-rc.2"
 dependencies = [
  "cosmwasm-std",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "cw-storage-plus"
-version = "3.0.0-rc.1"
+version = "3.0.0-rc.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2021"
 description = "Enhanced storage engines"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-storage-macro"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["yoisha <48324733+y-pakorn@users.noreply.github.com>"]
 edition = "2018"
 description = "Macro helpers for storage-plus"


### PR DESCRIPTION
Bumped the version of `cw-storage-macro` because it contains unreleased functionality (in version 2.0.0).