### PR TITLE
Bumped dependency to `cw-storage-macro`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,8 @@ dependencies = [
 [[package]]
 name = "cw-storage-macro"
 version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b853a2f7d85f286d099ae5b28ae4025c475d31145bf426cc6d86ec92afd215c8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -487,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "3.0.0-rc.1"
+version = "3.0.0-rc.2"
 dependencies = [
  "cosmwasm-std",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "cw-storage-plus"
-version = "3.0.0-rc.1"
+version = "3.0.0-rc.2"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2021"
 description = "Enhanced storage engines"
@@ -26,7 +26,7 @@ bench = false
 cosmwasm-std = { version = "3.0.0-rc.0", default-features = false, features = ["std"] }
 schemars = "0.8.22"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-cw-storage-macro = { version = "2.0.0", optional = true, path = "macros" }
+cw-storage-macro = { version = "2.1.0", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }


### PR DESCRIPTION
- Bumped dependency to `cw-storage-macro`.
- Removed **path = "macros"**  attribute from `cw-storage-macro` dependency, to avoid having tests passing locally in `cw-storage-plus` when tested functionality is not yet published in `cw-storage-macro`.