### PR TITLE
fix: return values from MultiIndex/UniqueIndex prefix_range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 
 [Unreleased] changes
 
+### Fixed
+
+- `MultiIndex::prefix_range` and `UniqueIndex::prefix_range` now return the stored
+  values instead of the primary-key length (or a deserialization error), matching
+  their `range` and `prefix_range_raw` siblings ([#125])
+
+[#125]: https://github.com/CosmWasm/cw-storage-plus/pull/125
+
 ---
 
 ## [3.0.1] - 2025-08-28

--- a/src/indexes/multi.rs
+++ b/src/indexes/multi.rs
@@ -10,7 +10,6 @@ use cosmwasm_std::{from_json, Order, Record, StdError, StdResult, Storage};
 use crate::bound::PrefixBound;
 use crate::de::KeyDeserialize;
 use crate::indexes::IndexPrefix;
-use crate::iter_helpers::deserialize_kv;
 use crate::map::Map;
 use crate::prefix::namespaced_prefix_range;
 use crate::{Bound, Index, Prefixer, PrimaryKey};
@@ -292,7 +291,7 @@ where
     /// There are some issues that distinguish these two, and blindly casting to `Vec<u8>` doesn't
     /// solve them.
     pub fn prefix_range<'c>(
-        &self,
+        &'c self,
         store: &'c dyn Storage,
         min: Option<PrefixBound<'a, IK>>,
         max: Option<PrefixBound<'a, IK>>,
@@ -306,7 +305,7 @@ where
         PK::Output: 'static,
     {
         let mapped = namespaced_prefix_range(store, self.idx_namespace, min, max, order)
-            .map(deserialize_kv::<PK, T>);
+            .map(move |kv| deserialize_multi_kv::<PK, T>(store, self.pk_namespace, kv));
         Box::new(mapped)
     }
 

--- a/src/indexes/unique.rs
+++ b/src/indexes/unique.rs
@@ -11,7 +11,6 @@ use cosmwasm_std::{from_json, Binary, Order, Record, StdError, StdResult, Storag
 use crate::bound::PrefixBound;
 use crate::de::KeyDeserialize;
 use crate::indexes::IndexPrefix;
-use crate::iter_helpers::deserialize_kv;
 use crate::map::Map;
 use crate::prefix::namespaced_prefix_range;
 use crate::{Bound, Index, Prefixer, PrimaryKey};
@@ -193,7 +192,7 @@ where
         PK::Output: 'static,
     {
         let mapped = namespaced_prefix_range(store, self.idx_namespace, min, max, order)
-            .map(deserialize_kv::<PK, T>);
+            .map(deserialize_unique_kv::<PK, T>);
         Box::new(mapped)
     }
 

--- a/tests/index_prefix_range.rs
+++ b/tests/index_prefix_range.rs
@@ -1,0 +1,109 @@
+//! Regression tests for `MultiIndex::prefix_range` / `UniqueIndex::prefix_range`.
+//!
+//! Both used to map their results with the generic `deserialize_kv` instead of the
+//! index-aware deserializer, so `prefix_range` returned the wrong data (the stored
+//! pk-length for `MultiIndex`, or a deserialization error) instead of the value that
+//! `range` and `prefix_range_raw` return. These tests pin the two methods to the same
+//! values their siblings produce.
+
+#![cfg(feature = "iterator")]
+
+use cosmwasm_std::testing::MockStorage;
+use cosmwasm_std::Order;
+use cw_storage_plus::{Index, IndexList, IndexedMap, MultiIndex, UniqueIndex};
+
+struct MultiIndexes<'a> {
+    // one shared index value so an unbounded prefix_range walks every entry
+    by_cat: MultiIndex<'a, u32, u64, String>,
+}
+
+impl IndexList<u64> for MultiIndexes<'_> {
+    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<u64>> + '_> {
+        Box::new(vec![&self.by_cat as &dyn Index<u64>].into_iter())
+    }
+}
+
+fn multi_map<'a>() -> IndexedMap<&'a str, u64, MultiIndexes<'a>> {
+    IndexedMap::new(
+        "m",
+        MultiIndexes {
+            by_cat: MultiIndex::new(|_pk, _v| 0u32, "m", "m__cat"),
+        },
+    )
+}
+
+#[test]
+fn multi_index_prefix_range_returns_values_not_pk_lengths() {
+    let mut store = MockStorage::new();
+    let map = multi_map();
+    map.save(&mut store, "a", &111_111).unwrap();
+    map.save(&mut store, "b", &222_222).unwrap();
+    map.save(&mut store, "c", &333_333).unwrap();
+
+    let by_range: Vec<u64> = map
+        .idx
+        .by_cat
+        .range(&store, None, None, Order::Ascending)
+        .map(|r| r.unwrap().1)
+        .collect();
+
+    let by_prefix_range: Vec<u64> = map
+        .idx
+        .by_cat
+        .prefix_range(&store, None, None, Order::Ascending)
+        .map(|r| r.unwrap().1)
+        .collect();
+
+    assert_eq!(by_range, vec![111_111, 222_222, 333_333]);
+    assert_eq!(
+        by_prefix_range, by_range,
+        "prefix_range must return the stored values, matching range()"
+    );
+}
+
+struct UniqueIndexes<'a> {
+    by_val: UniqueIndex<'a, u32, u64, String>,
+}
+
+impl IndexList<u64> for UniqueIndexes<'_> {
+    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<u64>> + '_> {
+        Box::new(vec![&self.by_val as &dyn Index<u64>].into_iter())
+    }
+}
+
+fn unique_map<'a>() -> IndexedMap<&'a str, u64, UniqueIndexes<'a>> {
+    IndexedMap::new(
+        "u",
+        UniqueIndexes {
+            by_val: UniqueIndex::new(|v| *v as u32, "u__val"),
+        },
+    )
+}
+
+#[test]
+fn unique_index_prefix_range_returns_values() {
+    let mut store = MockStorage::new();
+    let map = unique_map();
+    map.save(&mut store, "a", &10).unwrap();
+    map.save(&mut store, "b", &20).unwrap();
+
+    let by_range: Vec<u64> = map
+        .idx
+        .by_val
+        .range(&store, None, None, Order::Ascending)
+        .map(|r| r.unwrap().1)
+        .collect();
+
+    let by_prefix_range: Vec<u64> = map
+        .idx
+        .by_val
+        .prefix_range(&store, None, None, Order::Ascending)
+        .map(|r| r.unwrap().1)
+        .collect();
+
+    assert_eq!(by_range, vec![10, 20]);
+    assert_eq!(
+        by_prefix_range, by_range,
+        "UniqueIndex::prefix_range must return the stored values, matching range()"
+    );
+}


### PR DESCRIPTION
While going over how the index iterators deserialize their results, I noticed `MultiIndex::prefix_range` and `UniqueIndex::prefix_range` don't return what their siblings do.

Both end with `.map(deserialize_kv::<PK, T>)` — the deserializer for a plain `Map`, where the stored bytes *are* the serialized `T`. On an index that assumption doesn't hold:

- `MultiIndex` stores the primary-key length (`b"pk_len"`) at the index key and keeps the actual value in the primary namespace, so the value has to be recovered with a secondary load. `deserialize_kv` can't do that (no `pk_namespace`, no store access), so it runs `from_json::<T>` on the pk length.
- `UniqueIndex` stores a `UniqueRef { pk, value }`, so `from_json::<T>` runs on the whole wrapper instead of `.value`.

Effect on `prefix_range`:

- integer value type → you get the pk length back instead of the stored value (e.g. `1` instead of `111111`)
- any other value type → a deserialization error

Every other deserializing iterator on these types already uses the index-aware deserializers — `range`/`no_prefix` use `deserialize_multi_kv`, `prefix`/`range` on `UniqueIndex` use `deserialize_unique_kv`, and `prefix_range_raw` uses `deserialize_multi_v`. Only `prefix_range` was left on the generic one; it reads like a copy of `Map::prefix_range`, where `deserialize_kv` is the right call. Neither method is covered by tests, which is presumably why it slipped through.

The fix just switches them to the same deserializers the siblings use. `MultiIndex::prefix_range` now takes `&'c self`, since the closure borrows `pk_namespace` — same as `prefix_range_raw` directly above it.

I added a regression test for each index that iterates via `prefix_range` and checks the values match `range`. Full suite is green (168 existing + 2 new), and the touched files are clean under `cargo fmt`/`clippy`.
